### PR TITLE
Fix SPDX and unused params

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -40,8 +40,8 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
         PrizeInfo[] memory _prizes,
         address     _commissionToken,
         uint256     _commissionFee,
-        address[] memory _judges,
-        bytes memory _metadata
+        address[] memory /* _judges */, // unused for now
+        bytes memory /* _metadata */
     ) {
         registry        = _registry;
         creator         = _creator;

--- a/contracts/modules/contests/shared/PrizeInfo.sol
+++ b/contracts/modules/contests/shared/PrizeInfo.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
 /// @notice Тип приза: монетарный (ERC-20) или промо (офлайн-код)


### PR DESCRIPTION
## Summary
- add missing SPDX header
- comment unused constructor parameters

## Testing
- `npm run test` *(fails: Cannot find module `test/test-runner.js`)*

------
https://chatgpt.com/codex/tasks/task_e_685141f4bdc083238848f28a4cb94ac0