### PR TITLE
Fix alias keyword conflict in Registry

### DIFF
--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -26,7 +26,7 @@ contract Registry {
     event FeatureRegistered(bytes32 indexed id, address implementation, uint8 context);
     event CoreServiceSet(bytes32 indexed id, address serviceAddress);
     event ModuleServiceSet(bytes32 indexed moduleId, bytes32 indexed serviceId, address serviceAddress);
-    event ModuleRegistered(bytes32 indexed moduleId, string alias, address serviceAddress);
+    event ModuleRegistered(bytes32 indexed moduleId, string serviceAlias, address serviceAddress);
 
     modifier onlyAdmin() {
         require(access.hasRole(access.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
@@ -70,16 +70,16 @@ contract Registry {
     }
 
     /// @notice Привязать сервис к конкретному модулю
-    function setModuleService(bytes32 moduleId, bytes32 serviceId, address addr) external onlyFeatureOwner {
+    function setModuleService(bytes32 moduleId, bytes32 serviceId, address addr) public onlyFeatureOwner {
         require(features[moduleId].exists, "module not registered");
         moduleServices[moduleId][serviceId] = addr;
         emit ModuleServiceSet(moduleId, serviceId, addr);
     }
 
-    function setModuleServiceAlias(bytes32 moduleId, string calldata alias, address addr) external onlyFeatureOwner {
-        bytes32 serviceId = keccak256(bytes(alias));
+    function setModuleServiceAlias(bytes32 moduleId, string calldata serviceAlias, address addr) external onlyFeatureOwner {
+        bytes32 serviceId = keccak256(bytes(serviceAlias));
         setModuleService(moduleId, serviceId, addr);
-        emit ModuleRegistered(moduleId, alias, addr);
+        emit ModuleRegistered(moduleId, serviceAlias, addr);
     }
 
     /// @notice Получить сервис, закреплённый за модулем
@@ -87,8 +87,8 @@ contract Registry {
         return moduleServices[moduleId][serviceId];
     }
 
-    function getModuleService(bytes32 moduleId, string calldata alias) external view returns (address) {
-        return moduleServices[moduleId][keccak256(bytes(alias))];
+    function getModuleService(bytes32 moduleId, string calldata serviceAlias) external view returns (address) {
+        return moduleServices[moduleId][keccak256(bytes(serviceAlias))];
     }
 
     /// Позволяет заменить AccessControlCenter, если понадобится

--- a/contracts/interfaces/core/IRegistry.sol
+++ b/contracts/interfaces/core/IRegistry.sol
@@ -9,6 +9,6 @@ interface IRegistry {
     function getCoreService(bytes32 serviceId) external view returns (address);
     function setModuleService(bytes32 moduleId, bytes32 serviceId, address addr) external;
     function getModuleService(bytes32 moduleId, bytes32 serviceId) external view returns (address);
-    function setModuleServiceAlias(bytes32 moduleId, string calldata alias, address addr) external;
-    function getModuleService(bytes32 moduleId, string calldata alias) external view returns (address);
+    function setModuleServiceAlias(bytes32 moduleId, string calldata serviceAlias, address addr) external;
+    function getModuleService(bytes32 moduleId, string calldata serviceAlias) external view returns (address);
 }

--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -70,7 +70,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
             // 1) взимаем комиссию за on-chain действие
             if (commissionFee > 0) {
                 PaymentGateway(
-                    registry.getModuleService(MODULE_ID, "PaymentGateway")
+                    registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
                 ).processPayment(
                     MODULE_ID,
                     commissionToken,
@@ -104,7 +104,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
 
             // уведомляем остальные модули
             EventRouter(
-                registry.getModuleService(MODULE_ID, "EventRouter")
+                registry.getModuleService(MODULE_ID, keccak256(bytes("EventRouter")))
             ).route(
                 keccak256("ContestFinalized"),
                 abi.encode(creator, winners, prizes)
@@ -113,7 +113,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
             // чеканим бейджи
             string[] memory uris = new string[](winners.length);
             NFTManager(
-                registry.getModuleService(MODULE_ID, "NFTManager")
+                registry.getModuleService(MODULE_ID, keccak256(bytes("NFTManager")))
             ).mintBatch(winners, uris, false);
 
             emit ContestFinalized(winners);

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -67,7 +67,7 @@ contract ContestFactory is ReentrancyGuard {
     ) internal {
         // 1) Валидация токенов и схемы распределения, подсчёт призового пула
         TokenRegistry validator = TokenRegistry(
-            registry.getModuleService(MODULE_ID, "TokenRegistry")
+            registry.getModuleService(MODULE_ID, keccak256(bytes("TokenRegistry")))
         );
         uint256 totalMonetary;
         bytes32 moduleId = MODULE_ID;
@@ -90,7 +90,7 @@ contract ContestFactory is ReentrancyGuard {
         // 2) Сбор призового пула
         if (totalMonetary > 0) {
             PaymentGateway(
-                registry.getModuleService(MODULE_ID, "PaymentGateway")
+                registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
             ).processPayment(
             /*moduleId*/ moduleId,
                 slots[0].token,
@@ -102,7 +102,7 @@ contract ContestFactory is ReentrancyGuard {
         // 3) Сбор комиссии за finalize()
         if (params.commissionFee > 0) {
             PaymentGateway(
-                registry.getModuleService(MODULE_ID, "PaymentGateway")
+                registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
             ).processPayment(
             /*moduleId*/ moduleId,
                 params.commissionToken,


### PR DESCRIPTION
## Summary
- rename `alias` to `serviceAlias` in registry interface and implementation
- allow internal calls to `setModuleService`
- disambiguate service lookups using `keccak256(bytes(...))`

## Testing
- `npx hardhat compile`
- `npm test` *(fails: Cannot find module test-runner.js)*

------
https://chatgpt.com/codex/tasks/task_e_685171e223bc8323946c10c108d06e34