### PR TITLE
Fix module IDs and basic marketplace

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -31,7 +31,8 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
     event PromoPrizeIssued(uint8 indexed slot, address indexed to);
     event ContestFinalized(address[] winners);
 
-    bytes32 public constant MODULE_ID = keccak256("CONTEST_MODULE");
+    /// @dev Identifier used when interacting with registry services
+    bytes32 public constant MODULE_ID = keccak256("Contest");
 
     modifier onlyCreator() {
         require(msg.sender == creator, "Not creator");

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -16,7 +16,8 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 contract ContestFactory is ReentrancyGuard {
     Registry public immutable registry;
     bytes32 public constant FACTORY_ADMIN = keccak256("FACTORY_ADMIN");
-    bytes32 public constant MODULE_ID = keccak256("CONTEST_MODULE");
+    /// @dev Identifier used when interacting with registry services
+    bytes32 public constant MODULE_ID = keccak256("Contest");
 
     event ContestCreated(address indexed creator, address contest);
 
@@ -37,13 +38,13 @@ contract ContestFactory is ReentrancyGuard {
     ) external nonReentrant {
         // Проверяем роль
         AccessControlCenter acl = AccessControlCenter(
-            registry.getCoreService("AccessControlCenter")
+            registry.getCoreService(keccak256("AccessControlCenter"))
         );
         require(acl.hasRole(FACTORY_ADMIN, msg.sender), "Not FACTORY_ADMIN");
 
         // Получаем шаблон
         (PrizeInfo[] memory slots,) = IPrizeManager(
-            registry.getCoreService("PrizeManager")
+            registry.getCoreService(keccak256("PrizeManager"))
         ).getTemplate(templateId);
 
         _deployContest(slots, params);
@@ -54,7 +55,7 @@ contract ContestFactory is ReentrancyGuard {
         ContestParams calldata params
     ) external nonReentrant {
         AccessControlCenter acl = AccessControlCenter(
-            registry.getCoreService("AccessControlCenter")
+            registry.getCoreService(keccak256("AccessControlCenter"))
         );
         require(acl.hasRole(FACTORY_ADMIN, msg.sender), "Not FACTORY_ADMIN");
 

--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -1,8 +1,50 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-contract Marketplace {
-    constructor(){
+import "../../core/Registry.sol";
+import "../../core/PaymentGateway.sol";
 
+/// @title Marketplace
+/// @notice Minimal marketplace example demonstrating registration of sales and
+/// payment processing via the PaymentGateway core service.
+contract Marketplace {
+    Registry public immutable registry;
+    bytes32 public constant MODULE_ID = keccak256("Marketplace");
+
+    struct Listing {
+        address seller;
+        address token;
+        uint256 price;
+        bool active;
+    }
+
+    uint256 public nextId;
+    mapping(uint256 => Listing) public listings;
+
+    event Listed(uint256 indexed id, address indexed seller, address token, uint256 price);
+    event Sold(uint256 indexed id, address indexed buyer);
+
+    constructor(address _registry) {
+        registry = Registry(_registry);
+    }
+
+    /// @notice Put an item for sale
+    function list(address token, uint256 price) external returns (uint256 id) {
+        id = nextId++;
+        listings[id] = Listing(msg.sender, token, price, true);
+        emit Listed(id, msg.sender, token, price);
+    }
+
+    /// @notice Purchase a listed item, paying through PaymentGateway
+    function buy(uint256 id) external {
+        Listing storage l = listings[id];
+        require(l.active, "not listed");
+
+        PaymentGateway(
+            registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
+        ).processPayment(MODULE_ID, l.token, msg.sender, l.price);
+
+        l.active = false;
+        emit Sold(id, msg.sender);
     }
 }

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -1,8 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-contract SubscriptionManager {
-    constructor(){
+import "../../core/Registry.sol";
+import "../../core/PaymentGateway.sol";
 
+/// @title SubscriptionManager
+/// @notice Example subscription manager that charges users via PaymentGateway.
+contract SubscriptionManager {
+    Registry public immutable registry;
+    bytes32 public constant MODULE_ID = keccak256("Subscriptions");
+
+    mapping(address => uint256) public paidAmount;
+
+    event Subscribed(address indexed user, uint256 amount, address token);
+
+    constructor(address _registry) {
+        registry = Registry(_registry);
+    }
+
+    /// @notice Charge user for subscription using PaymentGateway
+    function subscribe(address token, uint256 amount) external {
+        PaymentGateway(
+            registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
+        ).processPayment(MODULE_ID, token, msg.sender, amount);
+
+        paidAmount[msg.sender] += amount;
+        emit Subscribed(msg.sender, amount, token);
     }
 }


### PR DESCRIPTION
## Summary
- add MODULE_ID to ContestEscrow/ContestFactory
- fix getCoreService bytes32 usage
- implement simple Marketplace and SubscriptionManager with PaymentGateway integration

## Testing
- `npm run compile`
- `npm run test:single`


------
https://chatgpt.com/codex/tasks/task_e_68517b9abffc8323b99d30571ebc2b20