### PR TITLE
Mark authorize upgrade functions view

### DIFF
--- a/contracts/core/AccessControlCenter.sol
+++ b/contracts/core/AccessControlCenter.sol
@@ -35,7 +35,7 @@ contract AccessControlCenter is Initializable, AccessControlUpgradeable, UUPSUpg
         return false;
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(newImplementation != address(0), "invalid implementation");
     }
 

--- a/contracts/core/CoreFeeManager.sol
+++ b/contracts/core/CoreFeeManager.sol
@@ -91,7 +91,7 @@ contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         access = AccessControlCenter(newAccess);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyAdmin {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
         require(newImplementation != address(0), "invalid implementation");
     }
 

--- a/contracts/core/EventRouter.sol
+++ b/contracts/core/EventRouter.sol
@@ -19,7 +19,7 @@ contract EventRouter is Initializable, UUPSUpgradeable {
         emit Routed(eventType, data);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override {
+    function _authorizeUpgrade(address newImplementation) internal view override {
         require(access.hasRole(access.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
         require(newImplementation != address(0), "invalid implementation");
     }

--- a/contracts/core/GasSubsidyManager.sol
+++ b/contracts/core/GasSubsidyManager.sol
@@ -74,7 +74,7 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
         access = AccessControlCenter(newAccess);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyAdmin {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
         require(newImplementation != address(0), "invalid implementation");
     }
 

--- a/contracts/core/PaymentGateway.sol
+++ b/contracts/core/PaymentGateway.sol
@@ -84,7 +84,7 @@ contract PaymentGateway is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     }
 
     /// @dev UUPS upgrade authorization
-    function _authorizeUpgrade(address newImplementation) internal override onlyAdmin {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
         require(newImplementation != address(0), "invalid implementation");
     }
 

--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -99,7 +99,7 @@ contract Registry is Initializable, UUPSUpgradeable {
         access = AccessControlCenter(newAccess);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyAdmin {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
         require(newImplementation != address(0), "invalid implementation");
     }
 

--- a/contracts/core/TokenRegistry.sol
+++ b/contracts/core/TokenRegistry.sol
@@ -49,7 +49,7 @@ contract TokenRegistry is Initializable, UUPSUpgradeable {
         access = AccessControlCenter(newAccess);
     }
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyAdmin {
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
         require(newImplementation != address(0), "invalid implementation");
     }
 


### PR DESCRIPTION
## Summary
- restrict `_authorizeUpgrade` functions to `view` across core contracts

## Testing
- `npm list --depth=0` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851dc1020908323948c7b9aef8738b5