### PR TITLE
Fix core payment checks and add controls

### DIFF
--- a/contracts/core/GasSubsidyManager.sol
+++ b/contracts/core/GasSubsidyManager.sol
@@ -62,7 +62,9 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
     /// @notice Refund gas to relayer with per-transaction limit check
     function refundGas(bytes32 moduleId, address payable relayer, uint256 gasUsed) external onlyAdmin {
         uint256 price = tx.gasprice;
-        require(gasUsed <= gasRefundPerTx[moduleId] / price, "Exceeds refund limit");
+        uint256 limit = gasRefundPerTx[moduleId];
+        require(limit > 0, "refund disabled");
+        require(gasUsed <= limit / price, "Exceeds refund limit");
         uint256 refund = price * gasUsed;
         require(address(this).balance >= refund, "Insufficient balance");
         relayer.transfer(refund);

--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -67,18 +67,6 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
 
         if (winners.length == 0) {
             winners = _winners;
-
-            // 1) взимаем комиссию за on-chain действие
-            if (commissionFee > 0) {
-                PaymentGateway(
-                    registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
-                ).processPayment(
-                    MODULE_ID,
-                    commissionToken,
-                    creator,
-                    commissionFee
-                );
-            }
         }
 
         uint256 start = processedWinners;

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -97,7 +97,8 @@ contract ContestFactory is ReentrancyGuard {
             /*moduleId*/ moduleId,
                 slots[0].token,
                 msg.sender,
-                totalMonetary
+                totalMonetary,
+                ""
             );
         }
 
@@ -109,7 +110,8 @@ contract ContestFactory is ReentrancyGuard {
             /*moduleId*/ moduleId,
                 params.commissionToken,
                 msg.sender,
-                params.commissionFee
+                params.commissionFee,
+                ""
             );
         }
 


### PR DESCRIPTION
## Summary
- prevent double fee collection by removing redundant finalize charge
- add pausable functionality for PaymentGateway and CoreFeeManager
- support signed payments in PaymentGateway
- check gas refund limit and zero value in GasSubsidyManager
- grant ACL roles for Marketplace and SubscriptionManager deployments
- add batch charge and unsubscribe helpers for subscriptions

## Testing
- `npm test` *(fails: Cannot find module 'test/test-runner.js')*
- `npx hardhat compile` *(fails: npm canceled due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68520064b36c8323a218db282d32cec9