### PR TITLE
Allow keeper automation charges

### DIFF
--- a/contracts/core/PaymentGateway.sol
+++ b/contracts/core/PaymentGateway.sol
@@ -73,15 +73,27 @@ contract PaymentGateway is Initializable, ReentrancyGuardUpgradeable, PausableUp
         bytes calldata signature
     ) external onlyFeatureOwner nonReentrant whenNotPaused returns (uint256 netAmount) {
         require(tokenRegistry.isTokenAllowed(moduleId, token), "token not allowed");
-        if (payer != msg.sender) {
-            bytes32 digest = keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    DOMAIN_SEPARATOR,
-                    keccak256(abi.encode(PROCESS_TYPEHASH, payer, moduleId, token, amount, nonces[payer]++, block.chainid))
-                )
-            );
-            require(ECDSA.recover(digest, signature) == payer, "invalid signature");
+        if (!access.hasRole(access.AUTOMATION_ROLE(), msg.sender)) {
+            if (payer != msg.sender) {
+                bytes32 digest = keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        DOMAIN_SEPARATOR,
+                        keccak256(
+                            abi.encode(
+                                PROCESS_TYPEHASH,
+                                payer,
+                                moduleId,
+                                token,
+                                amount,
+                                nonces[payer]++,
+                                block.chainid
+                            )
+                        )
+                    )
+                );
+                require(ECDSA.recover(digest, signature) == payer, "invalid signature");
+            }
         }
 
         IERC20(token).safeTransferFrom(payer, address(this), amount);

--- a/scripts/grantAutomationRole.ts
+++ b/scripts/grantAutomationRole.ts
@@ -1,0 +1,21 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const accessAddress = process.env.ACCESS_CONTROL_ADDRESS;
+  const keeperAddress = process.env.KEEPER_ADDRESS;
+  if (!accessAddress || !keeperAddress) {
+    throw new Error("ACCESS_CONTROL_ADDRESS and KEEPER_ADDRESS required");
+  }
+
+  const access = await ethers.getContractAt("AccessControlCenter", accessAddress);
+  const role = await access.AUTOMATION_ROLE();
+  const tx = await access.grantRole(role, keeperAddress);
+  await tx.wait();
+  console.log(`Granted AUTOMATION_ROLE to ${keeperAddress}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
## Summary
- allow AUTOMATION_ROLE to call `PaymentGateway.processPayment` without a signature
- add a deployment helper script to grant AUTOMATION_ROLE

## Testing
- `npm test` *(fails: Cannot find module 'test/test-runner.js')*
- `npm run compile` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685275b3bae083239fd27532a636f82f