### PR TITLE
Add relayer role support

### DIFF
--- a/scripts/grantRelayerRole.ts
+++ b/scripts/grantRelayerRole.ts
@@ -1,0 +1,20 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const accessAddress = process.env.ACCESS_CONTROL_ADDRESS;
+  const relayerAddress = process.env.RELAYER_ADDRESS;
+  if (!accessAddress || !relayerAddress) {
+    throw new Error("ACCESS_CONTROL_ADDRESS and RELAYER_ADDRESS required");
+  }
+
+  const access = await ethers.getContractAt("AccessControlCenter", accessAddress);
+  const role = await access.RELAYER_ROLE();
+  const tx = await access.grantRole(role, relayerAddress);
+  await tx.wait();
+  console.log(`Granted RELAYER_ROLE to ${relayerAddress}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- allow designated relayers to skip EIP-712 signatures
- add helper script to grant `RELAYER_ROLE`

## Testing
- `npm run compile`
- `npm test` *(fails: Cannot find module 'test/test-runner.js')*

------
https://chatgpt.com/codex/tasks/task_e_68527c28678483239ef84ec4f6499657