### PR TITLE
Fix chainIds hash collision in listing & plans

### DIFF
--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -124,7 +124,9 @@ contract Marketplace {
     }
 
     function hashListing(Listing calldata listing) public view returns (bytes32) {
-        bytes32 chainHash = keccak256(abi.encodePacked(listing.chainIds));
+        bytes32 chainHash = keccak256(
+            abi.encode(listing.chainIds.length, listing.chainIds)
+        );
         bytes32 structHash = keccak256(
             abi.encode(
                 LISTING_TYPEHASH,

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -67,7 +67,9 @@ contract SubscriptionManager {
     }
 
     function hashPlan(Plan calldata plan) public view returns (bytes32) {
-        bytes32 chainHash = keccak256(abi.encodePacked(plan.chainIds));
+        bytes32 chainHash = keccak256(
+            abi.encode(plan.chainIds.length, plan.chainIds)
+        );
         bytes32 structHash = keccak256(
             abi.encode(
                 PLAN_TYPEHASH,


### PR DESCRIPTION
## Summary
- ensure unique hashing of chain lists by including length in the hash

## Testing
- `npm test` *(fails: Cannot find module 'test/test-runner.js')*
- `npm run compile --silent` *(fails: requires installing hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685296de0b4483238dc72ed47b9c04c2