### PR TITLE
Add per-module token validator clones

### DIFF
--- a/contracts/core/AccessControlCenter.sol
+++ b/contracts/core/AccessControlCenter.sol
@@ -13,6 +13,8 @@ contract AccessControlCenter is Initializable, AccessControlUpgradeable, UUPSUpg
     bytes32 public constant MODULE_ROLE = keccak256("MODULE_ROLE");
     /// Role for automated keepers/cron jobs
     bytes32 public constant AUTOMATION_ROLE = keccak256("AUTOMATION_ROLE");
+    /// Role for managing token validators
+    bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
 
     function initialize(address admin) public initializer {
         __AccessControl_init();

--- a/contracts/core/MultiValidator.sol
+++ b/contracts/core/MultiValidator.sol
@@ -3,19 +3,22 @@ pragma solidity ^0.8.28;
 
 import "./AccessControlCenter.sol";
 
-/// @title MultiValidator (deprecated)
-/// @notice Legacy token whitelist contract, replaced by {TokenRegistry}.
+/// @title MultiValidator
+/// @notice Module-specific token whitelist deployed via minimal proxy clones.
 
-contract MultiValidator {
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+contract MultiValidator is Initializable, UUPSUpgradeable {
     AccessControlCenter public access;
 
-    // moduleId => token => разрешено ли
-    mapping(bytes32 => mapping(address => bool)) public isAllowed;
+    // token => allowed
+    mapping(address => bool) public allowed;
 
-    event TokenAllowed(bytes32 indexed moduleId, address indexed token, bool allowed);
+    event TokenAllowed(address indexed token, bool allowed);
 
-    modifier onlyFeatureOwner() {
-        require(access.hasRole(access.FEATURE_OWNER_ROLE(), msg.sender), "not feature owner");
+    modifier onlyGovernor() {
+        require(access.hasRole(access.GOVERNOR_ROLE(), msg.sender), "not governor");
         _;
     }
 
@@ -24,29 +27,36 @@ contract MultiValidator {
         _;
     }
 
-    constructor(address accessControl) {
-        access = AccessControlCenter(accessControl);
+    function initialize(address acl) public initializer {
+        __UUPSUpgradeable_init();
+        access = AccessControlCenter(acl);
+        access.grantRole(access.GOVERNOR_ROLE(), msg.sender);
     }
 
-    function setAllowed(bytes32 moduleId, address token, bool allowed) external onlyFeatureOwner {
+    function allow(address token, bool status) external onlyGovernor {
         require(token != address(0), "zero address");
-        isAllowed[moduleId][token] = allowed;
-        emit TokenAllowed(moduleId, token, allowed);
+        allowed[token] = status;
+        emit TokenAllowed(token, status);
     }
 
-    function bulkSetAllowed(bytes32 moduleId, address[] calldata tokens, bool allowed) external onlyFeatureOwner {
+    function bulkAllow(address[] calldata tokens, bool status) external onlyGovernor {
         for (uint i = 0; i < tokens.length; i++) {
-            isAllowed[moduleId][tokens[i]] = allowed;
-            emit TokenAllowed(moduleId, tokens[i], allowed);
+            allowed[tokens[i]] = status;
+            emit TokenAllowed(tokens[i], status);
         }
     }
 
-    function isTokenAllowed(bytes32 moduleId, address token) external view returns (bool) {
-        return isAllowed[moduleId][token];
+    function isAllowed(address token) external view returns (bool) {
+        return allowed[token];
     }
 
-    /// Позволяет заменить AccessControl в случае необходимости
     function setAccessControl(address newAccess) external onlyAdmin {
         access = AccessControlCenter(newAccess);
     }
+
+    function _authorizeUpgrade(address newImplementation) internal view override onlyAdmin {
+        require(newImplementation != address(0), "invalid implementation");
+    }
+
+    uint256[50] private __gap;
 }

--- a/contracts/interfaces/core/IMultiValidator.sol
+++ b/contracts/interfaces/core/IMultiValidator.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IMultiValidator {
+    function initialize(address acl) external;
+    function allow(address token, bool allowed) external;
+    function bulkAllow(address[] calldata tokens, bool allowed) external;
+    function isAllowed(address token) external view returns (bool);
+    function setAccessControl(address newAccess) external;
+}


### PR DESCRIPTION
## Summary
- introduce `GOVERNOR_ROLE` in `AccessControlCenter`
- rewrite `MultiValidator` as upgradeable cloneable logic
- use module-specific validators in `PaymentGateway`
- deploy validator clone from `ContestFactory`
- expose validator interface `IMultiValidator`

## Testing
- `npm run test:single`
- `npx hardhat compile`


------
https://chatgpt.com/codex/tasks/task_e_6852b5b2cdd08323ab3c592ec0929e7e