### PR TITLE
Implement batch charging and gas refund event

### DIFF
--- a/contracts/core/GasSubsidyManager.sol
+++ b/contracts/core/GasSubsidyManager.sol
@@ -20,6 +20,7 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
 
     event EligibilitySet(bytes32 moduleId, address user, bool allowed);
     event GasCoverageEnabled(bytes32 moduleId, address contractAddress, bool enabled);
+    event GasRefunded(bytes32 moduleId, address relayer, uint256 refund);
 
     /// Установить лимит возврата газа на одну транзакцию для модуля
     function setGasRefundLimit(bytes32 moduleId, uint256 limit) external onlyAdmin {
@@ -78,10 +79,12 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
         require(price > 0, "price zero");
         uint256 limit = gasRefundPerTx[moduleId];
         require(limit > 0, "refund disabled");
+        require(gasUsed > 0, "gas zero");
         require(gasUsed <= limit / price, "Exceeds refund limit");
         uint256 refund = price * gasUsed;
         require(address(this).balance >= refund, "Insufficient balance");
         relayer.transfer(refund);
+        emit GasRefunded(moduleId, relayer, refund);
     }
 
     receive() external payable {}

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -10,7 +10,6 @@ import "../../core/PaymentGateway.sol";
 import "./shared/PrizeInfo.sol";
 import "./interfaces/IPrizeManager.sol";
 import "./ContestEscrow.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 
 /// @title ContestFactory
 /// @notice Фабрика для создания конкурсов — по шаблону или с кастомным набором слотов
@@ -48,7 +47,7 @@ contract ContestFactory is ReentrancyGuard {
             address(this)
         );
         address val = predicted;
-        if (!Address.isContract(predicted)) {
+        if (predicted.code.length == 0) {
             val = Clones.cloneDeterministic(validatorLogic, salt);
             IMultiValidator(val).initialize(address(acl));
         }

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -155,8 +155,11 @@ contract SubscriptionManager {
     }
 
     function chargeBatch(address[] calldata users) external onlyAutomation {
-        for (uint256 i = 0; i < users.length; i++) {
-            charge(users[i]);
+        require(users.length <= 50, "batch limit");
+        unchecked {
+            for (uint256 i = 0; i < users.length; i++) {
+                charge(users[i]);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add a size-limited `chargeBatch` with unchecked loop in `SubscriptionManager`
- emit `GasRefunded` event and validate positive gas usage in `GasSubsidyManager`
- fix `ContestFactory` validator deployment for OZ 5.x

## Testing
- `npx hardhat test` *(fails: npm warns about http-proxy, then hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8e35d248323b249d5fba6f52ffe