### PR TITLE
Introduce shared interfaces for modules and gateway

### DIFF
--- a/contracts/core/PaymentGateway.sol
+++ b/contracts/core/PaymentGateway.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import "./AccessControlCenter.sol";
 import "../interfaces/core/IRegistry.sol";
-import "../interfaces/core/IMultiValidator.sol";
+import "../interfaces/IValidator.sol";
 import "./CoreFeeManager.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -75,7 +75,7 @@ contract PaymentGateway is Initializable, ReentrancyGuardUpgradeable, PausableUp
     ) external onlyFeatureOwner nonReentrant whenNotPaused returns (uint256 netAmount) {
         address val = registry.getModuleService(moduleId, keccak256(bytes("Validator")));
         require(
-            IMultiValidator(val).isAllowed(token),
+            IValidator(val).isAllowed(token),
             "token not allowed"
         );
         // Skip signature verification for automation bots and trusted relayers

--- a/contracts/interfaces/IFactory.sol
+++ b/contracts/interfaces/IFactory.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IFactory
+/// @notice Generic interface for module factories
+interface IFactory {
+    /// Emitted when a new module instance is deployed
+    event ModuleDeployed(address indexed creator, address module);
+
+    /// Deploy a new module instance using encoded parameters
+    function deploy(bytes calldata data) external returns (address module);
+}

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IGateway
+/// @notice Abstraction for payment gateways
+interface IGateway {
+    function processPayment(
+        bytes32 moduleId,
+        address token,
+        address payer,
+        uint256 amount,
+        bytes calldata signature
+    ) external returns (uint256 netAmount);
+}

--- a/contracts/interfaces/IModule.sol
+++ b/contracts/interfaces/IModule.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IModule
+/// @notice Base interface for feature modules
+interface IModule {
+    /// @dev Unique module identifier used for Registry lookups
+    function MODULE_ID() external view returns (bytes32);
+
+    /// @notice Optional callback invoked after a payment is processed
+    function onPayment(address token, uint256 amount, bytes calldata data) external;
+}

--- a/contracts/interfaces/IValidator.sol
+++ b/contracts/interfaces/IValidator.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IValidator
+/// @notice Minimal interface for token validators
+interface IValidator {
+    function isAllowed(address token) external view returns (bool);
+}

--- a/contracts/mocks/MockPaymentGateway.sol
+++ b/contracts/mocks/MockPaymentGateway.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../interfaces/IGateway.sol";
 
-contract MockPaymentGateway {
+contract MockPaymentGateway is IGateway {
     using SafeERC20 for IERC20;
 
     function processPayment(bytes32, address token, address payer, uint256 amount, bytes calldata) external returns (uint256) {

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -6,7 +6,8 @@ import "../../core/Registry.sol";
 import "../../core/AccessControlCenter.sol";
 import "../../interfaces/core/IMultiValidator.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
-import "../../core/PaymentGateway.sol";
+import "../../interfaces/IGateway.sol";
+import "../../interfaces/IValidator.sol";
 import "./shared/PrizeInfo.sol";
 import "./interfaces/IPrizeManager.sol";
 import "./ContestEscrow.sol";
@@ -89,7 +90,7 @@ contract ContestFactory is ReentrancyGuard {
         ContestParams memory params
     ) internal {
         // 1) Валидация токенов и схемы распределения, подсчёт призового пула
-        IMultiValidator validator = IMultiValidator(
+        IValidator validator = IValidator(
             registry.getModuleService(MODULE_ID, keccak256(bytes("Validator")))
         );
         uint256 totalMonetary;
@@ -112,10 +113,10 @@ contract ContestFactory is ReentrancyGuard {
 
         // 2) Сбор призового пула
         if (totalMonetary > 0) {
-            PaymentGateway(
+            IGateway(
                 registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
             ).processPayment(
-            /*moduleId*/ moduleId,
+                moduleId,
                 slots[0].token,
                 msg.sender,
                 totalMonetary,
@@ -125,10 +126,10 @@ contract ContestFactory is ReentrancyGuard {
 
         // 3) Сбор комиссии за finalize()
         if (params.commissionFee > 0) {
-            PaymentGateway(
+            IGateway(
                 registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
             ).processPayment(
-            /*moduleId*/ moduleId,
+                moduleId,
                 params.commissionToken,
                 msg.sender,
                 params.commissionFee,

--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import "../../core/Registry.sol";
-import "../../core/PaymentGateway.sol";
+import "../../interfaces/IGateway.sol";
 import "../../core/AccessControlCenter.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -82,7 +82,7 @@ contract Marketplace {
         OnchainListing storage l = listings[id];
         require(l.active, "not listed");
 
-        uint256 netAmount = PaymentGateway(
+        uint256 netAmount = IGateway(
             registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
         ).processPayment(MODULE_ID, l.token, msg.sender, l.price, "");
 
@@ -113,7 +113,7 @@ contract Marketplace {
         }
         require(chainAllowed, "invalid chain");
 
-        uint256 netAmount = PaymentGateway(
+        uint256 netAmount = IGateway(
             registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
         ).processPayment(MODULE_ID, listing.token, msg.sender, listing.price, "");
 

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import "../../core/Registry.sol";
-import "../../core/PaymentGateway.sol";
+import "../../interfaces/IGateway.sol";
 import "../../core/AccessControlCenter.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -115,7 +115,7 @@ contract SubscriptionManager {
             require(ok, "permit failed");
         }
 
-        uint256 netAmount = PaymentGateway(
+        uint256 netAmount = IGateway(
             registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
         ).processPayment(MODULE_ID, plan.token, msg.sender, plan.price, "");
 
@@ -143,7 +143,7 @@ contract SubscriptionManager {
         require(plan.merchant != address(0), "no plan");
         require(block.timestamp >= s.nextBilling, "not due");
 
-        uint256 netAmount = PaymentGateway(
+        uint256 netAmount = IGateway(
             registry.getModuleService(MODULE_ID, keccak256(bytes("PaymentGateway")))
         ).processPayment(MODULE_ID, plan.token, user, plan.price, "");
 


### PR DESCRIPTION
## Summary
- add new core interfaces (`IModule`, `IGateway`, `IFactory`, `IValidator`)
- refactor modules to use `IGateway` instead of direct `PaymentGateway` dependency
- use `IValidator` in `PaymentGateway` and `ContestFactory`
- update mock gateway to implement new interface

## Testing
- `npm test` *(fails: needs hardhat package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6852d0c203888323b28221c4e0395121