### PR TITLE
Implement AccessManaged helper

### DIFF
--- a/contracts/shared/AccessManaged.sol
+++ b/contracts/shared/AccessManaged.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../core/AccessControlCenter.sol";
+
+abstract contract AccessManaged {
+    address public immutable _ACC;
+
+    constructor(address acc) {
+        _ACC = acc;
+    }
+
+    function _grantSelfRoles(bytes32[] memory roles) internal {
+        AccessControlCenter(_ACC).grantMultipleRoles(address(this), roles);
+    }
+
+    modifier onlyRole(bytes32 role) {
+        AccessControlCenter acc = AccessControlCenter(_ACC);
+        require(acc.hasRole(role, msg.sender), "AC: forbidden");
+        _;
+    }
+}


### PR DESCRIPTION
## Summary
- add new AccessManaged helper for AccessControl
- refactor Marketplace and SubscriptionManager to use AccessManaged
- install dependencies and compile contracts

## Testing
- `npm run compile`
- `npm test` *(fails: Command failed: npx hardhat test)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd87cdf083238f0158840c7ff5a4