### PR TITLE
Add module setup docs and NatSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", gatewayAddress);
 
 Without this step modules won't be able to discover the gateway service.
 
+## Как добавить модуль
+
+1. Создайте смарт‑контракты модуля и необходимые сервисы.
+2. Задеплойте их в сеть и получите `moduleId`.
+3. Зарегистрируйте модуль в `Registry`:
+   ```solidity
+   registry.registerFeature(moduleId, moduleAddress, 1);
+   ```
+4. Установите алиасы сервисов, например `PaymentGateway`:
+   ```solidity
+   registry.setModuleServiceAlias(moduleId, "PaymentGateway", gatewayAddress);
+   ```
+
+```mermaid
+graph TD
+    A(Deploy contracts) --> B{Register in Registry}
+    B --> C[Set service aliases]
+    C --> D[Module ready]
+```
+
 ## Contributing & Support
 
 - **GitHub Issues**: [https://github.com/vitekes/evmcontest/issues](https://github.com/vitekes/evmcontest/issues)


### PR DESCRIPTION
## Summary
- document how to add a module with a mermaid diagram
- add comprehensive NatSpec comments to `SubscriptionManager`

## Testing
- `npx hardhat test test/subscription.ts` *(fails: Expected transaction NOT to be reverted)*

------
https://chatgpt.com/codex/tasks/task_e_685301adea208323beb162b3eae1a28f