### PR TITLE
Support permit

### DIFF
--- a/contracts/interfaces/IPermit2.sol
+++ b/contracts/interfaces/IPermit2.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IPermit2 {
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    struct SignatureTransferDetails {
+        address to;
+        uint256 requestedAmount;
+    }
+
+    function permitTransferFrom(
+        PermitTransferFrom calldata permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+}

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 describe("SubscriptionManager permit", function () {
-  it("uses Permit2 for subscribe", async function () {
+  it("allows subscribe with permit", async function () {
     const [owner, merchant] = await ethers.getSigners();
 
     const Token = await ethers.getContractFactory("TestToken");
@@ -13,18 +13,14 @@ describe("SubscriptionManager permit", function () {
 
     const Registry = await ethers.getContractFactory("MockRegistry");
     const registry = await Registry.deploy();
-    await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), acl.getAddress());
+    await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
 
     const Gateway = await ethers.getContractFactory("MockPaymentGateway");
     const gateway = await Gateway.deploy();
 
-    const Permit2 = await ethers.getContractFactory("MockPermit2");
-    const permit2 = await Permit2.deploy();
-
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
     const Manager = await ethers.getContractFactory("SubscriptionManager");
     const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
-    await registry.setModuleServiceAlias(moduleId, "Permit2", await permit2.getAddress());
 
     const plan = {
       chainIds: [31337n],
@@ -39,15 +35,108 @@ describe("SubscriptionManager permit", function () {
     const planHash = await manager.hashPlan(plan);
     const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
 
+    const nonce = await token.nonces(owner.address);
     const deadline = (await ethers.provider.getBlock("latest")).timestamp + 1000;
-    const permit = {
-      permitted: { token: await token.getAddress(), amount: plan.price },
-      nonce: 0n,
-      deadline: BigInt(deadline),
-    };
-    const details = { to: await gateway.getAddress(), requestedAmount: plan.price };
-    const permitSig = permit2.interface.encodeFunctionData("permitTransferFrom", [permit, details, owner.address, "0x"]);
+    const chainId = 31337;
+    const signature = await owner.signTypedData(
+      {
+        name: await token.name(),
+        version: "1",
+        chainId: chainId,
+        verifyingContract: await token.getAddress(),
+      },
+      { Permit: [
+        { name: "owner", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ] },
+      {
+        owner: owner.address,
+        spender: await gateway.getAddress(),
+        value: plan.price,
+        nonce: nonce,
+        deadline: deadline,
+      }
+    );
+    const sig = ethers.Signature.from(signature);
+    const permitSig = ethers.AbiCoder.defaultAbiCoder().encode([
+      "uint256",
+      "uint8",
+      "bytes32",
+      "bytes32",
+    ], [deadline, sig.v, sig.r, sig.s]);
 
     await expect(manager.subscribe(plan, sigMerchant, permitSig)).to.not.be.reverted;
+  });
+
+  it("reverts on bad permit signature", async function () {
+    const [owner, merchant, attacker] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy("Test", "TST");
+
+    const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+    const acl = await ACL.deploy();
+
+    const Registry = await ethers.getContractFactory("MockRegistry");
+    const registry = await Registry.deploy();
+    await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
+
+    const Gateway = await ethers.getContractFactory("MockPaymentGateway");
+    const gateway = await Gateway.deploy();
+
+    const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const Manager = await ethers.getContractFactory("SubscriptionManager");
+    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+
+    const plan = {
+      chainIds: [31337n],
+      price: ethers.parseEther("1"),
+      period: 100n,
+      token: await token.getAddress(),
+      merchant: merchant.address,
+      salt: 1n,
+      expiry: 0n,
+    } as const;
+
+    const planHash = await manager.hashPlan(plan);
+    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+
+    const nonce = await token.nonces(owner.address);
+    const deadline = (await ethers.provider.getBlock("latest")).timestamp + 1000;
+    const chainIdBad = 31337;
+    const signature = await attacker.signTypedData(
+      {
+        name: await token.name(),
+        version: "1",
+        chainId: chainIdBad,
+        verifyingContract: await token.getAddress(),
+      },
+      { Permit: [
+        { name: "owner", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ] },
+      {
+        owner: owner.address,
+        spender: await gateway.getAddress(),
+        value: plan.price,
+        nonce: nonce,
+        deadline: deadline,
+      }
+    );
+    const sig = ethers.Signature.from(signature);
+    const permitSig = ethers.AbiCoder.defaultAbiCoder().encode([
+      "uint256",
+      "uint8",
+      "bytes32",
+      "bytes32",
+    ], [deadline, sig.v, sig.r, sig.s]);
+
+    await expect(manager.subscribe(plan, sigMerchant, permitSig)).to.be.reverted;
   });
 });


### PR DESCRIPTION
## Summary
- add IPermit2 interface
- implement permit invocation with fallback to Permit2
- add tests for subscribe with ERC20 permit and invalid permit

## Testing
- `npx hardhat test test/subscription.ts --no-compile` *(fails: Expected transaction NOT to be reverted)*

------
https://chatgpt.com/codex/tasks/task_e_68532d26590c832396bad4e3d0c0b38b