### PR TITLE
Implement URI prize support

### DIFF
--- a/contracts/mocks/MockAccessControlCenter.sol
+++ b/contracts/mocks/MockAccessControlCenter.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.28;
 
 contract MockAccessControlCenter {
     bytes32 public constant FACTORY_ADMIN = keccak256("FACTORY_ADMIN");
+    bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
+    bytes32 public constant DEFAULT_ADMIN_ROLE = keccak256("DEFAULT_ADMIN_ROLE");
 
     function MODULE_ROLE() external pure returns (bytes32) {
         return keccak256("MODULE_ROLE");
@@ -13,6 +15,8 @@ contract MockAccessControlCenter {
     }
 
     function grantMultipleRoles(address, bytes32[] calldata) external {}
+
+    function grantRole(bytes32, address) external {}
 
     function hasRole(bytes32, address) external pure returns (bool) {
         return true;

--- a/contracts/modules/contests/shared/PrizeInfo.sol
+++ b/contracts/modules/contests/shared/PrizeInfo.sol
@@ -10,4 +10,5 @@ pragma solidity ^0.8.28;
         address   token;        // адрес ERC-20-токена (для MONETARY)
         uint256   amount;       // сумма токенов (для MONETARY)
         uint8     distribution; // схема распределения (0 = равномерно, 1 = нисходяще)
+        string    uri;          // описание/URI для неденежных призов
     }

--- a/test/contestFee.ts
+++ b/test/contestFee.ts
@@ -27,13 +27,13 @@ async function deployFactory() {
   await factory.setPriceFeed(await priceFeed.getAddress());
   await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
 
-  return { factory, token, priceFeed, registry };
+  return { factory, token, priceFeed, registry, gateway };
 }
 
 describe("ContestFactory fee", function () {
   it("uses price feed for commission", async function () {
     const [creator] = await ethers.getSigners();
-    const { factory, token, priceFeed } = await deployFactory();
+    const { factory, token, priceFeed, gateway } = await deployFactory();
 
     const params = {
       judges: [] as string[],
@@ -42,7 +42,7 @@ describe("ContestFactory fee", function () {
     };
 
     // Approve factory to pull tokens via gateway mock
-    await token.approve(await factory.getAddress(), ethers.parseEther("100"));
+  await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
 
     // test price 0.95 USD
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("0.95"));


### PR DESCRIPTION
## Summary
- allow URI prizes by extending PrizeInfo
- emit details of non-monetary prizes in ContestEscrow
- add addPrizes helper for creators
- make MultiValidator mock compatible with real contract
- adjust contestFee test to approve gateway

## Testing
- `npx hardhat test test/contestFee.ts`

------
https://chatgpt.com/codex/tasks/task_e_68533dd52dd88323bee8c59565767499