### PR TITLE
Implement gas pool with refund

### DIFF
--- a/contracts/core/CoreFeeManager.sol
+++ b/contracts/core/CoreFeeManager.sol
@@ -65,6 +65,14 @@ contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, PausableUp
         }
     }
 
+    /// @notice Deposit a specific amount of fees for a module without calculation
+    function depositFee(bytes32 moduleId, address token, uint256 amount) external onlyFeatureOwner nonReentrant whenNotPaused {
+        require(amount > 0, "amount zero");
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        collectedFees[moduleId][token] += amount;
+        emit FeeCollected(moduleId, token, amount);
+    }
+
     function withdrawFees(bytes32 moduleId, address token, address to) external onlyAdmin nonReentrant whenNotPaused {
         uint256 amount = collectedFees[moduleId][token];
         require(amount > 0, "nothing to withdraw");

--- a/contracts/interfaces/core/ICoreFeeManager.sol
+++ b/contracts/interfaces/core/ICoreFeeManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 interface ICoreFeeManager {
     function collect(bytes32 moduleId, address token, address payer, uint256 amount) external returns (uint256 feeAmount);
+    function depositFee(bytes32 moduleId, address token, uint256 amount) external;
     function withdrawFees(bytes32 moduleId, address token, address to) external;
     function setPercentFee(bytes32 moduleId, address token, uint16 feeBps) external;
     function setFixedFee(bytes32 moduleId, address token, uint256 feeAmount) external;


### PR DESCRIPTION
## Summary
- add depositFee hook to CoreFeeManager
- split commission between gas pool and platform fees
- track gasPool in ContestEscrow and refund finalization gas

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: npm http-proxy config prevents running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853472b7d4c8323896574618d4984ee