### PR TITLE
Add PrizeAssigned event for promo prizes

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -30,6 +30,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
 
     event MonetaryPrizePaid(address indexed to, uint256 amount);
     event PromoPrizeIssued(uint8 indexed slot, address indexed to, string uri);
+    event PrizeAssigned(address winner, string uri);
     event PrizeAdded(uint256 indexed slot, address indexed token, uint256 amount, string uri);
     event ContestFinalized(address[] winners);
     event GasRefunded(address indexed to, uint256 amount);
@@ -101,6 +102,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
                 emit MonetaryPrizePaid(winners[i], amount);
             } else {
                 emit PromoPrizeIssued(i, winners[i], p.uri);
+                emit PrizeAssigned(winners[i], p.uri);
             }
         }
 

--- a/test/prizeAssignment.ts
+++ b/test/prizeAssignment.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+async function deployFactory() {
+  const Token = await ethers.getContractFactory("TestToken");
+  const token = await Token.deploy("USD Coin", "USDC");
+
+  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const acl = await ACL.deploy();
+
+  const Registry = await ethers.getContractFactory("MockRegistry");
+  const registry = await Registry.deploy();
+  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
+
+  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
+  const gateway = await Gateway.deploy();
+
+  const PriceFeed = await ethers.getContractFactory("MockPriceFeed");
+  const priceFeed = await PriceFeed.deploy();
+
+  const Validator = await ethers.getContractFactory("MultiValidator");
+  const validatorLogic = await Validator.deploy();
+
+  const Factory = await ethers.getContractFactory("ContestFactory");
+  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
+
+  await factory.setPriceFeed(await priceFeed.getAddress());
+  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
+
+  return { factory, token, priceFeed, registry, gateway };
+}
+
+describe("PrizeAssigned event", function () {
+  it("emits for non monetary prize", async function () {
+    const [creator, winner] = await ethers.getSigners();
+    const { factory, token, priceFeed, gateway } = await deployFactory();
+
+    const params = {
+      judges: [] as string[],
+      metadata: "0x",
+      commissionToken: await token.getAddress(),
+    };
+
+    await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+    await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
+
+    const prizes = [
+      {
+        prizeType: 1,
+        token: ethers.ZeroAddress,
+        amount: 0,
+        distribution: 0,
+        uri: "ipfs://swag"
+      }
+    ];
+
+    const tx = await factory.createCustomContest(prizes, params);
+    const rc = await tx.wait();
+    const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
+    const contestAddr = ev?.args[1];
+    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+
+    const finalizeTx = await esc.finalize([winner.address]);
+    const receipt = await finalizeTx.wait();
+    const assigned = receipt?.logs.find((l: any) => l.fragment && l.fragment.name === "PrizeAssigned");
+    expect(assigned.args[0]).to.equal(winner.address);
+    expect(assigned.args[1]).to.equal("ipfs://swag");
+  });
+});


### PR DESCRIPTION
## Summary
- emit new `PrizeAssigned` event during `finalize`
- add unit test for promo prize assignment

## Testing
- `npx hardhat compile`
- `npx hardhat test` *(fails: npm warning about proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853c98c2b308323a27e36c78e62f59a