### PR TITLE
Add explicit token management for validators

### DIFF
--- a/contracts/core/MultiValidator.sol
+++ b/contracts/core/MultiValidator.sol
@@ -33,16 +33,23 @@ contract MultiValidator is Initializable, UUPSUpgradeable {
         access.grantRole(access.GOVERNOR_ROLE(), msg.sender);
     }
 
-    function allow(address token, bool status) external onlyGovernor {
+    function setToken(address token, bool status) public onlyGovernor {
         require(token != address(0), "zero address");
         allowed[token] = status;
         emit TokenAllowed(token, status);
     }
 
-    function bulkAllow(address[] calldata tokens, bool status) external onlyGovernor {
+    function addToken(address token) external onlyGovernor {
+        setToken(token, true);
+    }
+
+    function removeToken(address token) external onlyGovernor {
+        setToken(token, false);
+    }
+
+    function bulkSetToken(address[] calldata tokens, bool status) external onlyGovernor {
         for (uint i = 0; i < tokens.length; i++) {
-            allowed[tokens[i]] = status;
-            emit TokenAllowed(tokens[i], status);
+            setToken(tokens[i], status);
         }
     }
 

--- a/contracts/interfaces/core/IMultiValidator.sol
+++ b/contracts/interfaces/core/IMultiValidator.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.28;
 
 interface IMultiValidator {
     function initialize(address acl) external;
-    function allow(address token, bool allowed) external;
-    function bulkAllow(address[] calldata tokens, bool allowed) external;
+    function setToken(address token, bool allowed) external;
+    function addToken(address token) external;
+    function removeToken(address token) external;
+    function bulkSetToken(address[] calldata tokens, bool allowed) external;
     function isAllowed(address token) external view returns (bool);
     function setAccessControl(address newAccess) external;
 }

--- a/test/validator.ts
+++ b/test/validator.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("MultiValidator", function () {
+  it("adds and removes tokens with events", async function () {
+    const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+    const acl = await ACL.deploy();
+
+    const Validator = await ethers.getContractFactory("MultiValidator");
+    const val = await Validator.deploy();
+    await val.initialize(await acl.getAddress());
+
+    const token = "0x1000000000000000000000000000000000000001";
+
+    await expect(val.addToken(token))
+      .to.emit(val, "TokenAllowed")
+      .withArgs(token, true);
+    expect(await val.isAllowed(token)).to.equal(true);
+
+    await expect(val.removeToken(token))
+      .to.emit(val, "TokenAllowed")
+      .withArgs(token, false);
+    expect(await val.isAllowed(token)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add functions `addToken`, `removeToken` and `setToken`
- update `IMultiValidator` interface accordingly
- test token add/remove events

## Testing
- `npx hardhat test --no-compile` *(fails: canceled while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853e78d984c8323a9760f203ccd5b5b