### PR TITLE
Implement structured events

### DIFF
--- a/contracts/core/EventRouter.sol
+++ b/contracts/core/EventRouter.sol
@@ -8,16 +8,29 @@ import "../errors/Errors.sol";
 
 contract EventRouter is Initializable, UUPSUpgradeable {
     AccessControlCenter public access;
-    event Routed(bytes32 indexed eventType, bytes data);
+
+    enum EventKind {
+        Unknown,
+        ListingCreated,
+        PlanCancelled,
+        ContestFinalized
+    }
+
+    struct RoutedEvent {
+        EventKind kind;
+        bytes payload;
+    }
+
+    event EventRouted(EventKind indexed kind, bytes payload);
 
     function initialize(address accessControl) public initializer {
         __UUPSUpgradeable_init();
         access = AccessControlCenter(accessControl);
     }
 
-    function route(bytes32 eventType, bytes calldata data) external {
+    function route(EventKind kind, bytes calldata data) external {
         if (!access.hasRole(access.MODULE_ROLE(), msg.sender)) revert NotModule();
-        emit Routed(eventType, data);
+        emit EventRouted(kind, data);
     }
 
     function _authorizeUpgrade(address newImplementation) internal view override {

--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -125,7 +125,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
             EventRouter(
                 registry.getModuleService(MODULE_ID, keccak256(bytes("EventRouter")))
             ).route(
-                keccak256("ContestFinalized"),
+                EventRouter.EventKind.ContestFinalized,
                 abi.encode(creator, winners, prizes)
             );
 


### PR DESCRIPTION
## Summary
- standardize `EventRouter` interface with enum and typed routing
- update ContestEscrow to emit typed event routing

## Testing
- `npm run compile` *(fails: canceled by npm)*
- `npm test` *(fails: needs to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_6854215187048323bf1c414d44dabe34