### PR TITLE
Add gas tank funding events

### DIFF
--- a/contracts/core/CoreFeeManager.sol
+++ b/contracts/core/CoreFeeManager.sol
@@ -31,6 +31,7 @@ contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, PausableUp
 
     event FeeCollected(bytes32 indexed moduleId, address indexed token, uint256 amount);
     event FeeWithdrawn(bytes32 indexed moduleId, address indexed token, address to, uint256 amount);
+    event GasTankFunded(address indexed from, uint256 value, uint256 newBalance);
 
     modifier onlyFeatureOwner() {
         if (!access.hasRole(access.FEATURE_OWNER_ROLE(), msg.sender)) revert NotFeatureOwner();
@@ -82,6 +83,7 @@ contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, PausableUp
         IERC20(token).safeTransfer(to, amount);
 
         emit FeeWithdrawn(moduleId, token, to, amount);
+        emit GasTankFunded(to, amount, IERC20(token).balanceOf(to));
     }
 
     function setPercentFee(bytes32 moduleId, address token, uint16 feeBps) external onlyFeatureOwner {

--- a/contracts/core/GasSubsidyManager.sol
+++ b/contracts/core/GasSubsidyManager.sol
@@ -22,6 +22,7 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
     event EligibilitySet(bytes32 moduleId, address user, bool allowed);
     event GasCoverageEnabled(bytes32 moduleId, address contractAddress, bool enabled);
     event GasRefunded(bytes32 moduleId, address relayer, uint256 refund);
+    event GasTankFunded(address indexed from, uint256 value, uint256 newBalance);
 
     /// Установить лимит возврата газа на одну транзакцию для модуля
     function setGasRefundLimit(bytes32 moduleId, uint256 limit) external onlyAdmin {
@@ -88,7 +89,9 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
         emit GasRefunded(moduleId, relayer, refund);
     }
 
-    receive() external payable {}
+    receive() external payable {
+        emit GasTankFunded(msg.sender, msg.value, address(this).balance);
+    }
 
     function setAccessControl(address newAccess) external onlyAdmin {
         access = AccessControlCenter(newAccess);


### PR DESCRIPTION
## Summary
- emit `GasTankFunded` when the gas tank receives ETH
- also emit the same event during fee withdrawal

## Testing
- `npm test` *(fails: hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68543507aa90832396655656de42389c