### PR TITLE
Add Foundry skeleton and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - name: Install Foundry
+        run: |
+          curl -L https://foundry.paradigm.xyz | bash
+          source ~/.bashrc
+          foundryup
+      - run: forge install foundry-rs/forge-std OpenZeppelin/openzeppelin-contracts@v5.3.0 OpenZeppelin/openzeppelin-contracts-upgradeable@v5.3.0
+      - run: forge test -vv
       - run: npx hardhat test
       - run: npx hardhat coverage
       - name: Check coverage

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ node_modules
 /coverage
 /coverage.json
 
+# Foundry build artifacts
+/lib
+/out
+
 # Hardhat Ignition default folder for deployments against a local node
 ignition/deployments/chain-31337
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@
    npm run test
    ```
 
+## Как запустить Foundry
+
+1. Установите инструментарий Foundry:
+   ```bash
+   curl -L https://foundry.paradigm.xyz | bash
+   foundryup
+   ```
+2. Запустите тесты:
+   ```bash
+   forge test
+   ```
+
 ## Documentation
 
 For detailed information, see:

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,10 @@
+[profile.default]
+src = 'contracts'
+test = 'test/foundry'
+libs = ['lib']
+solc_version = '0.8.28'
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+
+gas_reports = ['*']

--- a/test/foundry/Core.t.sol
+++ b/test/foundry/Core.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+contract CoreTest is Test {
+    function testExample() public {
+        assertEq(uint256(1), uint256(1));
+    }
+}


### PR DESCRIPTION
## Summary
- add `foundry.toml` with compiler 0.8.28 and gas reports enabled
- add Foundry example test under `test/foundry`
- document running Foundry in README
- run Foundry tests in CI
- ignore Foundry build artifacts

## Testing
- `forge install foundry-rs/forge-std OpenZeppelin/openzeppelin-contracts@v5.3.0 OpenZeppelin/openzeppelin-contracts-upgradeable@v5.3.0`
- `forge test -vv`


------
https://chatgpt.com/codex/tasks/task_e_68544c37e17c832389fc68dab77ce4f9