### PR TITLE
Add Hardhat e2e test setup

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,8 +4,10 @@ import path from "path";
 import "@nomicfoundation/hardhat-toolbox";
 import "@nomicfoundation/hardhat-ignition";
 import "@typechain/hardhat";
+import "@nomicfoundation/hardhat-network-helpers";
 
 const config: HardhatUserConfig = {
+    defaultNetwork: "hardhat",
     solidity: {
         version: "0.8.28",
         settings: {
@@ -21,10 +23,11 @@ const config: HardhatUserConfig = {
             url: "http://127.0.0.1:8545"
         },
         hardhat: {
-            // Встроенная тестовая сеть
+            // Встроенная тестовая сеть с возможностью форка
             gas: 200000000,
             blockGasLimit: 200000000,
-            allowUnlimitedContractSize: true
+            allowUnlimitedContractSize: true,
+            forking: process.env.FORK_URL ? { url: process.env.FORK_URL } : undefined
         },
         sepolia: {
             url: process.env.SEPOLIA_URL || "",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
     "hardhat": "^2.23.0",
     "mocha": "^10.8.2",
     "ts-node": "^10.9.0",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.3.0",
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "dotenv": "^16.5.0",
+    "ethers": "^6.12.0",
     "solc": "0.8.30"
   },
   "compilerOptions": {

--- a/test/hardhat/basic.e2e.spec.ts
+++ b/test/hardhat/basic.e2e.spec.ts
@@ -1,0 +1,7 @@
+import { expect } from "chai";
+
+describe("basic e2e", function () {
+  it("should assert 1 equals 1", async function () {
+    expect(1).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal Hardhat e2e test
- extend Hardhat config with default network and forking
- install ethers and Hardhat network helpers

## Testing
- `npx hardhat test test/hardhat/basic.e2e.spec.ts --network hardhat`

------
https://chatgpt.com/codex/tasks/task_e_68544f8dae9c8323993c4654aea09f4f