### PR TITLE
Add foundry unit tests for payment and modules

### DIFF
--- a/test/foundry/CorePaymentProcessor.t.sol
+++ b/test/foundry/CorePaymentProcessor.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {PaymentGateway} from "contracts/core/PaymentGateway.sol";
+import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
+import {MultiValidator} from "contracts/core/MultiValidator.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract CorePaymentProcessorTest is Test {
+    PaymentGateway gateway;
+    CoreFeeManager fee;
+    MultiValidator validator;
+    MockRegistry registry;
+    MockAccessControlCenter acc;
+    TestToken token;
+
+    bytes32 constant MODULE_ID = keccak256("Core");
+
+    function setUp() public {
+        acc = new MockAccessControlCenter();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+
+        fee = new CoreFeeManager();
+        fee.initialize(address(acc));
+
+        gateway = new PaymentGateway();
+        gateway.initialize(address(acc), address(registry), address(fee));
+
+        validator = new MultiValidator();
+        validator.initialize(address(acc));
+        registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        token = new TestToken("Test", "TST");
+        validator.addToken(address(token));
+    }
+
+    function testProcessPaymentHappy() public {
+        fee.setPercentFee(MODULE_ID, address(token), 1000); // 10%
+        uint256 start = token.balanceOf(address(this));
+        token.approve(address(gateway), 100 ether);
+
+        uint256 net = gateway.processPayment(MODULE_ID, address(token), address(this), 100 ether, "");
+        assertEq(net, 90 ether);
+        assertEq(token.balanceOf(address(this)), start - 10 ether);
+    }
+
+    function testProcessPaymentNotWhitelisted() public {
+        TestToken bad = new TestToken("Bad", "BAD");
+        bad.approve(address(gateway), 1 ether);
+        vm.expectRevert("NotAllowedToken()");
+        gateway.processPayment(MODULE_ID, address(bad), address(this), 1 ether, "");
+    }
+}

--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {Marketplace} from "contracts/modules/marketplace/Marketplace.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract MarketplaceTest is Test {
+    MockRegistry registry;
+    MockAccessControlCenter acc;
+    MockPaymentGateway gateway;
+    Marketplace market;
+    TestToken token;
+
+    uint256 sellerPk = 1;
+    uint256 buyerPk = 2;
+    address seller;
+    address buyer;
+
+    bytes32 constant MODULE_ID = keccak256("Market");
+
+    function setUp() public {
+        seller = vm.addr(sellerPk);
+        buyer = vm.addr(buyerPk);
+
+        acc = new MockAccessControlCenter();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+        gateway = new MockPaymentGateway();
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        market = new Marketplace(address(registry), address(gateway), MODULE_ID);
+
+        token = new TestToken("Test", "TST");
+        token.transfer(seller, 100 ether);
+        token.transfer(buyer, 100 ether);
+
+        vm.prank(buyer);
+        token.approve(address(gateway), type(uint256).max);
+    }
+
+    function _listing() internal view returns (SignatureLib.Listing memory l) {
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = block.chainid;
+        l = SignatureLib.Listing({
+            chainIds: chains,
+            token: address(token),
+            price: 1 ether,
+            sku: bytes32("1"),
+            seller: seller,
+            salt: 1,
+            expiry: 0
+        });
+    }
+
+    function testLazyBuy() public {
+        SignatureLib.Listing memory l = _listing();
+        bytes32 hash = market.hashListing(l);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(sellerPk, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        uint256 beforeBal = token.balanceOf(seller);
+        vm.prank(buyer);
+        market.buy(l, sig);
+        assertEq(token.balanceOf(seller), beforeBal + 1 ether);
+        assertTrue(market.consumed(hash, buyer));
+    }
+
+    function testLazyBuyTampered() public {
+        SignatureLib.Listing memory l = _listing();
+        bytes32 hash = market.hashListing(l);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(sellerPk, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        l.price = 2 ether;
+        vm.prank(buyer);
+        vm.expectRevert("InvalidSignature()");
+        market.buy(l, sig);
+    }
+}

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {SubscriptionManager} from "contracts/modules/subscriptions/SubscriptionManager.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract SubscriptionManagerTest is Test {
+    MockRegistry registry;
+    MockAccessControlCenter acc;
+    MockPaymentGateway gateway;
+    SubscriptionManager manager;
+    TestToken token;
+
+    uint256 userPk = 1;
+    uint256 merchantPk = 2;
+    address user;
+    address merchant;
+
+    bytes32 constant MODULE_ID = keccak256("Sub");
+
+    function setUp() public {
+        user = vm.addr(userPk);
+        merchant = vm.addr(merchantPk);
+
+        acc = new MockAccessControlCenter();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+        gateway = new MockPaymentGateway();
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
+
+        token = new TestToken("Test", "TST");
+        token.transfer(user, 10 ether);
+    }
+
+    function _plan() internal view returns (SignatureLib.Plan memory p) {
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = block.chainid;
+        p = SignatureLib.Plan({
+            chainIds: chains,
+            price: 1 ether,
+            period: 100,
+            token: address(token),
+            merchant: merchant,
+            salt: 1,
+            expiry: 0
+        });
+    }
+
+    function _merchantSig(SignatureLib.Plan memory p) internal returns (bytes memory) {
+        bytes32 ph = manager.hashPlan(p);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, ph);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _permitSig(uint256 pk, uint256 value, uint256 deadline) internal view returns (bytes memory) {
+        uint256 nonce = token.nonces(user);
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+                user,
+                address(gateway),
+                value,
+                nonce,
+                deadline
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", token.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encode(deadline, v, r, s);
+    }
+
+    function testSubscribeWithPermit() public {
+        SignatureLib.Plan memory p = _plan();
+        bytes memory sigMerchant = _merchantSig(p);
+        uint256 deadline = block.timestamp + 1000;
+        bytes memory permitSig = _permitSig(userPk, p.price, deadline);
+        vm.prank(user);
+        manager.subscribe(p, sigMerchant, permitSig);
+        assertEq(token.balanceOf(merchant), p.price);
+        (uint256 nextBilling, bytes32 planHash) = manager.subscribers(user);
+        assertEq(planHash, manager.hashPlan(p));
+        assertEq(nextBilling, block.timestamp + p.period);
+    }
+
+    function testSubscribeInvalidPermit() public {
+        SignatureLib.Plan memory p = _plan();
+        bytes memory sigMerchant = _merchantSig(p);
+        uint256 deadline = block.timestamp + 1000;
+        bytes memory permitSig = _permitSig(merchantPk, p.price, deadline);
+        vm.expectRevert();
+        vm.prank(user);
+        manager.subscribe(p, sigMerchant, permitSig);
+    }
+}


### PR DESCRIPTION
## Summary
- add payment gateway unit tests
- test marketplace lazy-buy path and signature validation
- cover subscription manager subscribe with permit

## Testing
- `forge test -v`
- `forge coverage --ir-minimum --summary`

------
https://chatgpt.com/codex/tasks/task_e_6854550970ec83239e3e62a3d0e68185