### PR TITLE
Add Chainlink fork e2e test

### DIFF
--- a/contracts/mocks/ChainlinkPriceFeed.sol
+++ b/contracts/mocks/ChainlinkPriceFeed.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../interfaces/IPriceFeed.sol";
+import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+/// @title ChainlinkPriceFeed
+/// @notice Reads USD price from Chainlink feeds
+contract ChainlinkPriceFeed is IPriceFeed {
+    mapping(address => address) public aggregators;
+
+    function setAggregator(address token, address feed) external {
+        aggregators[token] = feed;
+    }
+
+    function tokenPriceUsd(address token) external view returns (uint256) {
+        address feed = aggregators[token];
+        if (feed == address(0)) return 0;
+        (, int256 answer,, ,) = AggregatorV3Interface(feed).latestRoundData();
+        uint8 decimals = AggregatorV3Interface(feed).decimals();
+        if (answer <= 0) return 0;
+        return uint256(answer) * (10 ** (18 - decimals));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "@openzeppelin/contracts-upgradeable": "^5.3.0",
     "dotenv": "^16.5.0",
     "ethers": "^6.12.0",
-    "solc": "0.8.30"
+    "solc": "0.8.30",
+    "@chainlink/contracts": "^1.4.0"
   },
   "compilerOptions": {
     "target": "ES2022",

--- a/test/hardhat/basic.e2e.spec.ts
+++ b/test/hardhat/basic.e2e.spec.ts
@@ -1,7 +1,0 @@
-import { expect } from "chai";
-
-describe("basic e2e", function () {
-  it("should assert 1 equals 1", async function () {
-    expect(1).to.equal(1);
-  });
-});

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+async function deployCore() {
+  const Token = await ethers.getContractFactory("TestToken");
+  const token = await Token.deploy("USD Coin", "USDC");
+
+  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const acl = await ACL.deploy();
+
+  const Registry = await ethers.getContractFactory("MockRegistry");
+  const registry = await Registry.deploy();
+  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
+
+  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
+  const gateway = await Gateway.deploy();
+
+  const PriceFeed = await ethers.getContractFactory("ChainlinkPriceFeed");
+  const priceFeed = await PriceFeed.deploy();
+
+  const Validator = await ethers.getContractFactory("MultiValidator");
+  const validatorLogic = await Validator.deploy();
+
+  const Factory = await ethers.getContractFactory("ContestFactory");
+  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
+
+  await factory.setPriceFeed(await priceFeed.getAddress());
+  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
+
+  return { factory, token, priceFeed, registry, gateway };
+}
+
+describe("fork e2e", function () {
+  it("deploys contest and finalizes prizes", async function () {
+    if (!network.config.forking?.url) {
+      console.log("Skipping: not a forked network");
+      this.skip();
+    }
+
+    const [creator, winner] = await ethers.getSigners();
+    await network.provider.send("hardhat_setBalance", [creator.address, "0x21e19e0c9bab2400000"]); // 1000 ETH
+
+    const { factory, token, priceFeed, registry, gateway } = await deployCore();
+
+    // configure chainlink feed for our test token
+    const FEED = "0xab5c6c3c1626d9052d3b714d8813bb69cf2ce317"; // USDC/USD on Goerli
+    await priceFeed.setAggregator(await token.getAddress(), FEED);
+
+    // allow token via validator
+    const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+    const validatorAddr = await registry.getModuleService(moduleId, "Validator");
+    await network.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
+    const factorySigner = await ethers.getSigner(await factory.getAddress());
+    const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+    await validator.connect(factorySigner).addToken(await token.getAddress());
+    await network.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
+
+    // approve tokens for gateway
+    await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+
+    const params = {
+      judges: [] as string[],
+      metadata: "0x",
+      commissionToken: await token.getAddress(),
+    };
+
+    const prizes = [
+      {
+        prizeType: 0,
+        token: await token.getAddress(),
+        amount: ethers.parseEther("10"),
+        distribution: 0,
+        uri: "",
+      },
+    ];
+
+    const tx = await factory.createCustomContest(prizes, params);
+    const rc = await tx.wait();
+    const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
+    const contestAddr = ev?.args[1];
+    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+
+    const fee = await esc.commissionFee();
+    expect(fee).to.be.gte(ethers.parseEther("5"));
+    expect(fee).to.be.lte(ethers.parseEther("10"));
+
+    await esc.finalize([winner.address]);
+    expect(await token.balanceOf(winner.address)).to.equal(ethers.parseEther("10"));
+
+    console.log("✅ E2E passed");
+  });
+});


### PR DESCRIPTION
## Summary
- add ChainlinkPriceFeed contract for live price feeds
- create Hardhat e2e test that forks Goerli, deploys core, and finalizes a contest
- remove old placeholder e2e spec
- add Chainlink contracts dependency

## Testing
- `npx hardhat compile`
- `FORK_URL=https://rpc.ankr.com/eth_goerli npm test` *(fails: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68545fe2d77c8323a9aae17623fd4487