### PR TITLE
Add EventRouter validation test

### DIFF
--- a/test/eventRouter.ts
+++ b/test/eventRouter.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("EventRouter", function () {
+  it("reverts on unknown kind", async function () {
+    const [owner] = await ethers.getSigners();
+
+    const ACC = await ethers.getContractFactory("AccessControlCenter");
+    const acc = await ACC.deploy();
+    await acc.initialize(owner.address);
+    await acc.grantRole(await acc.MODULE_ROLE(), owner.address);
+
+    const Router = await ethers.getContractFactory("EventRouter");
+    const router = await Router.deploy();
+    await router.initialize(await acc.getAddress());
+
+    await expect(router.route(0, "0x")).to.be.revertedWithCustomError(
+      router,
+      "InvalidKind"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering `InvalidKind` revert in `EventRouter`

## Testing
- `npx hardhat test test/eventRouter.ts --no-compile`

------
https://chatgpt.com/codex/tasks/task_e_6854f5ee98b88323b244751a38ef3f30