### PR TITLE
Use real ACL in validator tests

### DIFF
--- a/test/validator.ts
+++ b/test/validator.ts
@@ -3,12 +3,20 @@ import { ethers } from "hardhat";
 
 describe("MultiValidator", function () {
   it("adds and removes tokens with events", async function () {
-    const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+    const [admin] = await ethers.getSigners();
+
+    const ACL = await ethers.getContractFactory("AccessControlCenter");
     const acl = await ACL.deploy();
+    await acl.initialize(admin.address);
 
     const Validator = await ethers.getContractFactory("MultiValidator");
     const val = await Validator.deploy();
+
+    // allow validator to grant roles during initialize
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), await val.getAddress());
     await val.initialize(await acl.getAddress());
+
+    expect(await acl.hasRole(await acl.GOVERNOR_ROLE(), admin.address)).to.equal(true);
 
     const token = "0x1000000000000000000000000000000000000001";
 
@@ -21,5 +29,23 @@ describe("MultiValidator", function () {
       .to.emit(val, "TokenAllowed")
       .withArgs(token, false);
     expect(await val.isAllowed(token)).to.equal(false);
+  });
+
+  it("reverts for non governor", async function () {
+    const [admin, attacker] = await ethers.getSigners();
+
+    const ACL = await ethers.getContractFactory("AccessControlCenter");
+    const acl = await ACL.deploy();
+    await acl.initialize(admin.address);
+
+    const Validator = await ethers.getContractFactory("MultiValidator");
+    const val = await Validator.deploy();
+
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), await val.getAddress());
+    await val.initialize(await acl.getAddress());
+
+    await expect(
+      val.connect(attacker).addToken("0x2000000000000000000000000000000000000002")
+    ).to.be.revertedWithCustomError(val, "NotGovernor");
   });
 });


### PR DESCRIPTION
## Summary
- strengthen MultiValidator tests by deploying the real AccessControlCenter
- verify governor role assignment
- test failure for unauthorized addToken

## Testing
- `npx hardhat test test/validator.ts --grep "MultiValidator"`

------
https://chatgpt.com/codex/tasks/task_e_685513e376888323aa19bfa147213728