### PR TITLE
Add subscription tests

### DIFF
--- a/contracts/mocks/MockAccessControlCenterAuto.sol
+++ b/contracts/mocks/MockAccessControlCenterAuto.sol
@@ -27,6 +27,8 @@ contract MockAccessControlCenterAuto {
     function grantRole(bytes32, address) external {}
 
     function hasRole(bytes32 role, address) external pure returns (bool) {
-        return role == keccak256('FEATURE_OWNER_ROLE') || role == keccak256('AUTOMATION_ROLE');
+        return role == keccak256('FEATURE_OWNER_ROLE') ||
+            role == keccak256('AUTOMATION_ROLE') ||
+            role == keccak256('GOVERNOR_ROLE');
     }
 }

--- a/lib/chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol
+++ b/lib/chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+    function description() external view returns (string memory);
+    function version() external view returns (uint256);
+
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,6 @@
+ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/
+erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
+forge-std/=lib/forge-std/src/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+@chainlink/=lib/chainlink/

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {SubscriptionManager} from "contracts/modules/subscriptions/SubscriptionManager.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenterAuto} from "contracts/mocks/MockAccessControlCenterAuto.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract SubscriptionBatchTest is Test {
+    MockRegistry registry;
+    MockAccessControlCenterAuto acc;
+    MockPaymentGateway gateway;
+    SubscriptionManager manager;
+    TestToken token;
+
+    uint256 merchantPk = 1;
+    address merchant;
+
+    bytes32 constant MODULE_ID = keccak256("Sub");
+
+    function setUp() public {
+        merchant = vm.addr(merchantPk);
+
+        acc = new MockAccessControlCenterAuto();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+        gateway = new MockPaymentGateway();
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
+
+        token = new TestToken("Test", "TST");
+    }
+
+    function _plan() internal view returns (SignatureLib.Plan memory p) {
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = block.chainid;
+        p = SignatureLib.Plan({
+            chainIds: chains,
+            price: 1 ether,
+            period: 100,
+            token: address(token),
+            merchant: merchant,
+            salt: 1,
+            expiry: 0
+        });
+    }
+
+    function _merchantSig(SignatureLib.Plan memory p) internal returns (bytes memory) {
+        bytes32 ph = manager.hashPlan(p);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, ph);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _subscribeUsers(uint256 count) internal returns (address[] memory addrs) {
+        SignatureLib.Plan memory p = _plan();
+        bytes memory sigMerchant = _merchantSig(p);
+
+        addrs = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            address user = vm.addr(uint256(100 + i));
+            addrs[i] = user;
+            token.transfer(user, 10 ether);
+            vm.startPrank(user);
+            token.approve(address(gateway), type(uint256).max);
+            manager.subscribe(p, sigMerchant, "");
+            vm.stopPrank();
+        }
+    }
+
+    function _warpToNextPeriod(SignatureLib.Plan memory p) internal {
+        vm.warp(block.timestamp + p.period);
+    }
+
+    function testChargeBatchLessThanLimit() public {
+        address[] memory users = _subscribeUsers(3);
+        SignatureLib.Plan memory p = _plan();
+        manager.setBatchLimit(5);
+        _warpToNextPeriod(p);
+        uint256 bal0 = token.balanceOf(merchant);
+        manager.chargeBatch(users);
+        uint256 bal1 = token.balanceOf(merchant);
+        assertEq(bal1 - bal0, p.price * users.length);
+    }
+
+    function testChargeBatchExactLimit() public {
+        address[] memory users = _subscribeUsers(5);
+        SignatureLib.Plan memory p = _plan();
+        manager.setBatchLimit(5);
+        _warpToNextPeriod(p);
+        uint256 bal0 = token.balanceOf(merchant);
+        manager.chargeBatch(users);
+        uint256 bal1 = token.balanceOf(merchant);
+        assertEq(bal1 - bal0, p.price * users.length);
+    }
+
+    function testChargeBatchExcessLimit() public {
+        address[] memory users = _subscribeUsers(7);
+        SignatureLib.Plan memory p = _plan();
+        manager.setBatchLimit(5);
+        _warpToNextPeriod(p);
+        uint256 bal0 = token.balanceOf(merchant);
+        manager.chargeBatch(users);
+        uint256 bal1 = token.balanceOf(merchant);
+        assertEq(bal1 - bal0, p.price * 5);
+        for (uint256 i = 0; i < users.length; i++) {
+            (uint256 nextBilling,) = manager.subscribers(users[i]);
+            if (i < 5) {
+                assertEq(nextBilling, block.timestamp + p.period);
+            } else {
+                assertEq(nextBilling, block.timestamp); // unchanged (since warp sets to block.timestamp)
+            }
+        }
+    }
+
+    function testChargeBatchNotDue() public {
+        address[] memory users = _subscribeUsers(2);
+        manager.setBatchLimit(5);
+        vm.expectRevert("NotDue()");
+        manager.chargeBatch(users);
+    }
+}

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {SubscriptionManager} from "contracts/modules/subscriptions/SubscriptionManager.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract SubscriptionFlowTest is Test {
+    MockRegistry registry;
+    MockAccessControlCenter acc;
+    MockPaymentGateway gateway;
+    SubscriptionManager manager;
+    TestToken token;
+
+    uint256 userPk = 1;
+    uint256 merchantPk = 2;
+    address user;
+    address merchant;
+
+    bytes32 constant MODULE_ID = keccak256("Sub");
+
+    function setUp() public {
+        user = vm.addr(userPk);
+        merchant = vm.addr(merchantPk);
+
+        acc = new MockAccessControlCenter();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+        gateway = new MockPaymentGateway();
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
+
+        token = new TestToken("Test", "TST");
+        token.transfer(user, 10 ether);
+
+        vm.prank(user);
+        token.approve(address(gateway), type(uint256).max);
+    }
+
+    function _plan() internal view returns (SignatureLib.Plan memory p) {
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = block.chainid;
+        p = SignatureLib.Plan({
+            chainIds: chains,
+            price: 1 ether,
+            period: 100,
+            token: address(token),
+            merchant: merchant,
+            salt: 1,
+            expiry: 0
+        });
+    }
+
+    function _merchantSig(SignatureLib.Plan memory p) internal returns (bytes memory) {
+        bytes32 ph = manager.hashPlan(p);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, ph);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testUnsubscribeClearsRecord() public {
+        SignatureLib.Plan memory p = _plan();
+        bytes memory sigMerchant = _merchantSig(p);
+
+        vm.prank(user);
+        manager.subscribe(p, sigMerchant, "");
+
+        vm.warp(block.timestamp + 1);
+        uint256 ts = block.timestamp;
+        bytes32 ph = manager.hashPlan(p);
+
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionManager.Unsubscribed(user, ph);
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionManager.PlanCancelled(user, ph, ts);
+
+        vm.prank(user);
+        manager.unsubscribe();
+
+        (uint256 nextBilling, bytes32 planHash) = manager.subscribers(user);
+        assertEq(nextBilling, 0);
+        assertEq(planHash, bytes32(0));
+    }
+}


### PR DESCRIPTION
## Summary
- extend MockAccessControlCenterAuto with GOVERNOR_ROLE for tests
- add minimal Chainlink interface and remappings
- create SubscriptionFlow and SubscriptionBatch foundry tests

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_68556bd1932c8323808b9a5ab526b7bf