### PR TITLE
Add meta TX and replay tests

### DIFF
--- a/contracts/mocks/MockForwarder.sol
+++ b/contracts/mocks/MockForwarder.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../core/AccessControlCenter.sol";
+
+contract MockForwarder {
+    AccessControlCenter public access;
+
+    error InvalidForwarder();
+
+    constructor(address _access) {
+        access = AccessControlCenter(_access);
+    }
+
+    function execute(address target, bytes calldata data) external {
+        if (!access.hasRole(access.RELAYER_ROLE(), msg.sender)) revert InvalidForwarder();
+        (bool ok, bytes memory err) = target.call(data);
+        if (!ok) {
+            assembly {
+                revert(add(err, 32), mload(err))
+            }
+        }
+    }
+}

--- a/test/foundry/EventRouter.t.sol
+++ b/test/foundry/EventRouter.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {EventRouter} from "contracts/core/EventRouter.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+
+contract EventRouterTest is Test {
+    AccessControlCenter acc;
+    EventRouter router;
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        router = new EventRouter();
+        router.initialize(address(acc));
+        acc.grantRole(acc.MODULE_ROLE(), address(this));
+    }
+
+    function testRouteUnknownKind() public {
+        vm.expectRevert("InvalidKind()");
+        router.route(EventRouter.EventKind.Unknown, "");
+    }
+}

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {Marketplace} from "contracts/modules/marketplace/Marketplace.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract MarketplaceReplayTest is Test {
+    MockRegistry registry;
+    MockAccessControlCenter acc;
+    MockPaymentGateway gateway;
+    Marketplace market;
+    TestToken token;
+
+    uint256 sellerPk = 1;
+    uint256 buyerPk = 2;
+    address seller;
+    address buyer;
+
+    bytes32 constant MODULE_ID = keccak256("Market");
+
+    function setUp() public {
+        seller = vm.addr(sellerPk);
+        buyer = vm.addr(buyerPk);
+
+        acc = new MockAccessControlCenter();
+        registry = new MockRegistry();
+        registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
+        gateway = new MockPaymentGateway();
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        market = new Marketplace(address(registry), address(gateway), MODULE_ID);
+
+        token = new TestToken("Test", "TST");
+        token.transfer(seller, 100 ether);
+        token.transfer(buyer, 100 ether);
+
+        vm.prank(buyer);
+        token.approve(address(gateway), type(uint256).max);
+    }
+
+    function _listing() internal view returns (SignatureLib.Listing memory l) {
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = block.chainid;
+        l = SignatureLib.Listing({
+            chainIds: chains,
+            token: address(token),
+            price: 1 ether,
+            sku: bytes32("1"),
+            seller: seller,
+            salt: 1,
+            expiry: 0
+        });
+    }
+
+    function testLazyBuyReplay() public {
+        SignatureLib.Listing memory l = _listing();
+        bytes32 hash = market.hashListing(l);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(sellerPk, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.prank(buyer);
+        market.buy(l, sig);
+
+        vm.prank(buyer);
+        vm.expectRevert("AlreadyPurchased()");
+        market.buy(l, sig);
+    }
+}

--- a/test/hardhat/metaTx.spec.ts
+++ b/test/hardhat/metaTx.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("meta transaction", function () {
+  it("allows relayer with role to pay", async function () {
+    const [admin, payer, relayer, bad] = await ethers.getSigners();
+
+    const ACC = await ethers.getContractFactory("AccessControlCenter");
+    const acc = await ACC.deploy();
+    await acc.initialize(admin.address);
+
+    const Registry = await ethers.getContractFactory("MockRegistry");
+    const registry = await Registry.deploy();
+    await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acc.getAddress());
+
+    const Fee = await ethers.getContractFactory("CoreFeeManager");
+    const fee = await Fee.deploy();
+    await fee.initialize(await acc.getAddress());
+
+    const Gateway = await ethers.getContractFactory("PaymentGateway");
+    const gateway = await Gateway.deploy();
+    await gateway.initialize(await acc.getAddress(), await registry.getAddress(), await fee.getAddress());
+
+    const Validator = await ethers.getContractFactory("MultiValidator");
+    const validator = await Validator.deploy();
+    await acc.grantRole(await acc.DEFAULT_ADMIN_ROLE(), await validator.getAddress());
+    await validator.initialize(await acc.getAddress());
+
+    const MODULE_ID = ethers.keccak256(ethers.toUtf8Bytes("Core"));
+    await registry.setModuleServiceAlias(MODULE_ID, "Validator", await validator.getAddress());
+
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy("USD Coin", "USDC");
+    await validator.addToken(await token.getAddress());
+    await token.transfer(payer.address, ethers.parseEther("10"));
+    await token.connect(payer).approve(await gateway.getAddress(), ethers.parseEther("10"));
+
+    const Forwarder = await ethers.getContractFactory("MockForwarder");
+    const forwarder = await Forwarder.deploy(await acc.getAddress());
+
+    await acc.grantRole(await acc.FEATURE_OWNER_ROLE(), forwarder.getAddress());
+    await acc.grantRole(await acc.RELAYER_ROLE(), forwarder.getAddress());
+    await acc.grantRole(await acc.RELAYER_ROLE(), relayer.address);
+
+    const data = gateway.interface.encodeFunctionData("processPayment", [
+      MODULE_ID,
+      await token.getAddress(),
+      payer.address,
+      ethers.parseEther("1"),
+      "0x",
+    ]);
+
+    await forwarder.connect(relayer).execute(await gateway.getAddress(), data);
+    expect(await token.balanceOf(await forwarder.getAddress())).to.equal(ethers.parseEther("1"));
+
+    await expect(
+      forwarder.connect(bad).execute(await gateway.getAddress(), data)
+    ).to.be.revertedWithCustomError(forwarder, "InvalidForwarder");
+  });
+});


### PR DESCRIPTION
## Summary
- add simple forwarder mock
- add foundry tests for EventRouter and replay check for Marketplace
- add hardhat test for meta transaction payment

## Testing
- `forge test`
- `npx hardhat test` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68557a456e988323bb6978eff0802ceb