### PR TITLE
Fix GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: npm ci
+      - run: npm install
       - name: Install Foundry
         run: |
           curl -L https://foundry.paradigm.xyz | bash


### PR DESCRIPTION
## Summary
- run `npm install` instead of `npm ci`

## Testing
- `npm run test` *(fails: Cannot install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6855876b3fd08323b8300494956f34ca