### PR TITLE
Switch tests to real ACL and add demo script

### DIFF
--- a/scripts/showcase-all.ts
+++ b/scripts/showcase-all.ts
@@ -1,0 +1,101 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer, buyer, keeper, winner] = await ethers.getSigners();
+
+  console.log("Deploying core modules...");
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
+  const acl = await ACL.deploy();
+  await acl.initialize(deployer.address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, deployer.address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), deployer.address);
+  await acl.grantRole(await acl.AUTOMATION_ROLE(), keeper.address);
+
+  const Registry = await ethers.getContractFactory("Registry");
+  const registry = await Registry.deploy();
+  await registry.initialize(await acl.getAddress());
+
+  const Fee = await ethers.getContractFactory("CoreFeeManager");
+  const fee = await Fee.deploy();
+  await fee.initialize(await acl.getAddress());
+
+  const Gateway = await ethers.getContractFactory("PaymentGateway");
+  const gateway = await Gateway.deploy();
+  await gateway.initialize(await acl.getAddress(), await registry.getAddress(), await fee.getAddress());
+
+  const Token = await ethers.getContractFactory("TestToken");
+  const token = await Token.deploy("Demo", "DEMO");
+  await token.transfer(buyer.address, ethers.parseEther("100"));
+
+  console.log("Deploying feature modules...");
+  const Validator = await ethers.getContractFactory("MultiValidator");
+  const marketValidator = await Validator.deploy();
+  await marketValidator.initialize(await acl.getAddress());
+  await marketValidator.addToken(await token.getAddress());
+
+  const subValidator = await Validator.deploy();
+  await subValidator.initialize(await acl.getAddress());
+  await subValidator.addToken(await token.getAddress());
+
+  const ContestFactory = await ethers.getContractFactory("ContestFactory");
+  const validatorLogic = await Validator.deploy();
+  const contestFactory = await ContestFactory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
+
+  const Marketplace = await ethers.getContractFactory("Marketplace");
+  const MARKET_ID = ethers.keccak256(ethers.toUtf8Bytes("Market"));
+  const market = await Marketplace.deploy(await registry.getAddress(), await gateway.getAddress(), MARKET_ID);
+  await registry.setModuleServiceAlias(MARKET_ID, "Validator", await marketValidator.getAddress());
+
+  const SubManager = await ethers.getContractFactory("SubscriptionManager");
+  const SUB_ID = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+  const sub = await SubManager.deploy(await registry.getAddress(), await gateway.getAddress(), SUB_ID);
+  await registry.setModuleServiceAlias(SUB_ID, "Validator", await subValidator.getAddress());
+
+  console.log("Running marketplace demo...");
+  const listingIdTx = await market.list(await token.getAddress(), ethers.parseEther("1"));
+  const listingId = (await listingIdTx.wait())?.logs[0].args[0];
+  await token.connect(buyer).approve(await gateway.getAddress(), ethers.parseEther("1"));
+  await market.connect(buyer).buy(listingId);
+  console.log("Buyer purchased listing");
+
+  console.log("Running subscription demo...");
+  const plan = {
+    chainIds: [31337n],
+    price: ethers.parseEther("2"),
+    period: 60n,
+    token: await token.getAddress(),
+    merchant: deployer.address,
+    salt: 1n,
+    expiry: 0n,
+  } as const;
+  const planHash = await sub.hashPlan(plan);
+  const sigMerchant = await deployer.signMessage(ethers.getBytes(planHash));
+  await token.connect(buyer).approve(await gateway.getAddress(), plan.price);
+  await sub.connect(buyer).subscribe(plan, sigMerchant, "0x");
+  await ethers.provider.send("evm_increaseTime", [61]);
+  await ethers.provider.send("evm_mine", []);
+  await sub.connect(keeper).chargeBatch([buyer.address]);
+  console.log("Subscription charged");
+
+  console.log("Running contest demo...");
+  const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
+  await token.approve(await gateway.getAddress(), ethers.parseEther("20"));
+  const prizes = [
+    { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("10"), distribution: 0, uri: "" },
+    { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("5"), distribution: 0, uri: "" },
+  ];
+  const tx = await contestFactory.createCustomContest(prizes, params);
+  const rc = await tx.wait();
+  const created = rc?.logs.find(l => l.fragment && l.fragment.name === "ContestCreated");
+  const contestAddr = created?.args[1];
+  const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+  await gateway.connect(winner); // just to silence ts
+  await esc.finalize([winner.address, deployer.address]);
+  console.log("Contest finalized, winner balance:", (await token.balanceOf(winner.address)).toString());
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/contestFee.ts
+++ b/test/contestFee.ts
@@ -5,8 +5,12 @@ async function deployFactory() {
   const Token = await ethers.getContractFactory("TestToken");
   const token = await Token.deploy("USD Coin", "USDC");
 
-  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
   const acl = await ACL.deploy();
+  await acl.initialize((await ethers.getSigners())[0].address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, (await ethers.getSigners())[0].address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), (await ethers.getSigners())[0].address);
 
   const Registry = await ethers.getContractFactory("MockRegistry");
   const registry = await Registry.deploy();

--- a/test/contestFinalize.ts
+++ b/test/contestFinalize.ts
@@ -5,8 +5,12 @@ async function deployFactory() {
   const Token = await ethers.getContractFactory("TestToken");
   const token = await Token.deploy("USD Coin", "USDC");
 
-  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
   const acl = await ACL.deploy();
+  await acl.initialize((await ethers.getSigners())[0].address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, (await ethers.getSigners())[0].address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), (await ethers.getSigners())[0].address);
 
   const Registry = await ethers.getContractFactory("MockRegistry");
   const registry = await Registry.deploy();

--- a/test/gateway.ts
+++ b/test/gateway.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("PaymentGateway access", function () {
+  it("reverts for caller without feature owner role", async function () {
+    const [admin, user] = await ethers.getSigners();
+
+    const ACC = await ethers.getContractFactory("AccessControlCenter");
+    const acc = await ACC.deploy();
+    await acc.initialize(admin.address);
+
+    const Registry = await ethers.getContractFactory("MockRegistry");
+    const registry = await Registry.deploy();
+    await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acc.getAddress());
+
+    const Fee = await ethers.getContractFactory("CoreFeeManager");
+    const fee = await Fee.deploy();
+    await fee.initialize(await acc.getAddress());
+
+    const Gateway = await ethers.getContractFactory("PaymentGateway");
+    const gateway = await Gateway.deploy();
+    await gateway.initialize(await acc.getAddress(), await registry.getAddress(), await fee.getAddress());
+
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy("Test", "TST");
+    await token.transfer(user.address, ethers.parseEther("1"));
+    await token.connect(user).approve(await gateway.getAddress(), ethers.parseEther("1"));
+
+    const MODULE_ID = ethers.keccak256(ethers.toUtf8Bytes("Core"));
+    await expect(
+      gateway.connect(user).processPayment(MODULE_ID, await token.getAddress(), user.address, ethers.parseEther("1"), "0x")
+    ).to.be.revertedWithCustomError(gateway, "NotFeatureOwner");
+  });
+});

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -5,8 +5,12 @@ async function deployCore() {
   const Token = await ethers.getContractFactory("TestToken");
   const token = await Token.deploy("USD Coin", "USDC");
 
-  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
   const acl = await ACL.deploy();
+  await acl.initialize((await ethers.getSigners())[0].address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, (await ethers.getSigners())[0].address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), (await ethers.getSigners())[0].address);
 
   const Registry = await ethers.getContractFactory("MockRegistry");
   const registry = await Registry.deploy();

--- a/test/prizeAssignment.ts
+++ b/test/prizeAssignment.ts
@@ -5,8 +5,12 @@ async function deployFactory() {
   const Token = await ethers.getContractFactory("TestToken");
   const token = await Token.deploy("USD Coin", "USDC");
 
-  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
   const acl = await ACL.deploy();
+  await acl.initialize((await ethers.getSigners())[0].address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, (await ethers.getSigners())[0].address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), (await ethers.getSigners())[0].address);
 
   const Registry = await ethers.getContractFactory("MockRegistry");
   const registry = await Registry.deploy();


### PR DESCRIPTION
## Summary
- use `AccessControlCenter` in Hardhat tests
- add negative test for PaymentGateway access
- enforce automation role check in subscription tests
- create integration showcase script using all modules

## Testing
- `npm test` *(fails: needs hardhat installation)*

------
https://chatgpt.com/codex/tasks/task_e_6855ad7ae7688323a7c2f32a7018e095