### PR TITLE
Centralize signature hashing

### DIFF
--- a/contracts/interfaces/CoreDefs.sol
+++ b/contracts/interfaces/CoreDefs.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title CoreDefs
+/// @notice Common core constants used across modules
+library CoreDefs {
+    bytes32 internal constant SERVICE_PAYMENT_GATEWAY = keccak256('PaymentGateway');
+    bytes32 internal constant SERVICE_VALIDATOR = keccak256('Validator');
+    bytes32 internal constant CONTEST_MODULE_ID = keccak256('Contest');
+}

--- a/contracts/lib/SignatureLib.sol
+++ b/contracts/lib/SignatureLib.sol
@@ -32,14 +32,46 @@ library SignatureLib {
             'Plan(uint256[] chainIds,uint256 price,uint256 period,address token,address merchant,uint256 salt,uint64 expiry)'
         );
 
+    bytes32 internal constant PROCESS_TYPEHASH =
+        keccak256(
+            'ProcessPayment(address payer,bytes32 moduleId,address token,uint256 amount,uint256 nonce,uint256 chainId)'
+        );
+
+    function _hashTypedDataV4(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked('\x19\x01', domainSeparator, structHash));
+    }
+
     function hashListing(Listing calldata l) internal pure returns (bytes32) {
         bytes32 chainHash = keccak256(abi.encode(l.chainIds.length, l.chainIds));
         return keccak256(abi.encode(LISTING_TYPEHASH, chainHash, l.token, l.price, l.sku, l.seller, l.salt, l.expiry));
+    }
+
+    function hashListing(Listing calldata l, bytes32 domainSeparator) internal pure returns (bytes32) {
+        return _hashTypedDataV4(domainSeparator, hashListing(l));
     }
 
     function hashPlan(Plan calldata p) internal pure returns (bytes32) {
         bytes32 chainHash = keccak256(abi.encode(p.chainIds.length, p.chainIds));
         return
             keccak256(abi.encode(PLAN_TYPEHASH, chainHash, p.price, p.period, p.token, p.merchant, p.salt, p.expiry));
+    }
+
+    function hashPlan(Plan calldata p, bytes32 domainSeparator) internal pure returns (bytes32) {
+        return _hashTypedDataV4(domainSeparator, hashPlan(p));
+    }
+
+    function hashProcessPayment(
+        bytes32 domainSeparator,
+        address payer,
+        bytes32 moduleId,
+        address token,
+        uint256 amount,
+        uint256 nonce,
+        uint256 chainId
+    ) internal pure returns (bytes32) {
+        bytes32 structHash = keccak256(
+            abi.encode(PROCESS_TYPEHASH, payer, moduleId, token, amount, nonce, chainId)
+        );
+        return _hashTypedDataV4(domainSeparator, structHash);
     }
 }

--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -8,6 +8,7 @@ import '../../shared/NFTManager.sol';
 import '../../errors/Errors.sol';
 import './shared/PrizeInfo.sol';
 import './interfaces/IContestEscrow.sol';
+import '../../interfaces/CoreDefs.sol';
 import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
@@ -38,7 +39,7 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
     event GasRefunded(address indexed to, uint256 amount);
 
     /// @dev Identifier used when interacting with registry services
-    bytes32 public constant MODULE_ID = keccak256('Contest');
+    bytes32 public constant MODULE_ID = CoreDefs.CONTEST_MODULE_ID;
 
     modifier onlyCreator() {
         if (msg.sender != creator) revert NotCreator();

--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -9,6 +9,7 @@ import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import '../../lib/SignatureLib.sol';
+import '../../interfaces/CoreDefs.sol';
 import '../../errors/Errors.sol';
 
 /// @title Marketplace
@@ -91,7 +92,7 @@ contract Marketplace is AccessManaged {
         OnchainListing storage l = listings[id];
         if (!l.active) revert NotListed();
 
-        uint256 netAmount = IGateway(registry.getModuleService(MODULE_ID, keccak256(bytes('PaymentGateway'))))
+        uint256 netAmount = IGateway(registry.getModuleService(MODULE_ID, CoreDefs.SERVICE_PAYMENT_GATEWAY))
             .processPayment(MODULE_ID, l.token, msg.sender, l.price, '');
 
         IERC20(l.token).safeTransfer(l.seller, netAmount);
@@ -114,7 +115,7 @@ contract Marketplace is AccessManaged {
         }
         if (!chainAllowed) revert InvalidChain();
 
-        uint256 netAmount = IGateway(registry.getModuleService(MODULE_ID, keccak256(bytes('PaymentGateway'))))
+        uint256 netAmount = IGateway(registry.getModuleService(MODULE_ID, CoreDefs.SERVICE_PAYMENT_GATEWAY))
             .processPayment(MODULE_ID, listing.token, msg.sender, listing.price, '');
 
         IERC20(listing.token).safeTransfer(listing.seller, netAmount);
@@ -124,7 +125,6 @@ contract Marketplace is AccessManaged {
     }
 
     function hashListing(SignatureLib.Listing calldata listing) public view returns (bytes32) {
-        bytes32 structHash = SignatureLib.hashListing(listing);
-        return keccak256(abi.encodePacked('\x19\x01', DOMAIN_SEPARATOR, structHash));
+        return SignatureLib.hashListing(listing, DOMAIN_SEPARATOR);
     }
 }

--- a/contracts/modules/marketplace/MarketplaceFactory.sol
+++ b/contracts/modules/marketplace/MarketplaceFactory.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import '../../shared/BaseFactory.sol';
 import './Marketplace.sol';
+import '../../interfaces/CoreDefs.sol';
 
 contract MarketplaceFactory is BaseFactory {
     event MarketplaceCreated(address indexed creator, address marketplace);
@@ -13,7 +14,7 @@ contract MarketplaceFactory is BaseFactory {
     ) BaseFactory(registry, paymentGateway, keccak256('Marketplace')) {}
 
     function createMarketplace() external onlyFactoryAdmin nonReentrant returns (address m) {
-        address gateway = registry.getModuleService(MODULE_ID, keccak256(bytes('PaymentGateway')));
+        address gateway = registry.getModuleService(MODULE_ID, CoreDefs.SERVICE_PAYMENT_GATEWAY);
         m = address(new Marketplace(address(registry), gateway, MODULE_ID));
         registry.registerFeature(keccak256(abi.encodePacked('Marketplace:', m)), m, 1);
         emit MarketplaceCreated(msg.sender, m);

--- a/contracts/shared/BaseFactory.sol
+++ b/contracts/shared/BaseFactory.sol
@@ -5,6 +5,7 @@ import '../interfaces/core/IRegistry.sol';
 import '../core/AccessControlCenter.sol';
 import '../errors/Errors.sol';
 import './CloneFactory.sol';
+import '../interfaces/CoreDefs.sol';
 import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 
 abstract contract BaseFactory is CloneFactory, ReentrancyGuard {


### PR DESCRIPTION
## Summary
- extract core constants
- refactor EIP‑712 helpers into `SignatureLib`
- use new helpers across modules

## Testing
- `npx hardhat compile` *(fails: needs to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6855e30b61548323972222ebf1d5a0e6