### PR TITLE
Fix fuzz role check in GatewayModuleFeeFuzzTest

### DIFF
--- a/test/foundry/GatewayModuleFeeFuzz.t.sol
+++ b/test/foundry/GatewayModuleFeeFuzz.t.sol
@@ -34,6 +34,7 @@ contract GatewayModuleFeeFuzzTest is Test {
         fee.initialize(address(acc));
 
         gateway = new PaymentGateway();
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
         gateway.initialize(address(acc), address(registry), address(fee));
 
         validator = new AlwaysValidator();


### PR DESCRIPTION
## Summary
- grant `FEATURE_OWNER_ROLE` to the gateway inside `GatewayModuleFeeFuzzTest` setup

## Testing
- `forge test --match-contract CorePaymentProcessorTest -vvv`
- `forge test --match-contract GatewayModuleFeeFuzzTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6855f7ea71e083239378e4b0b7191c59