### PR TITLE
Fix module roles in tests

### DIFF
--- a/test/foundry/AccessControl.t.sol
+++ b/test/foundry/AccessControl.t.sol
@@ -41,13 +41,13 @@ contract AccessControlTest is Test {
 
     function testAddTokenNotGovernor() public {
         vm.prank(address(1));
-        vm.expectRevert("Forbidden()");
+        vm.expectRevert("NotGovernor()");
         validator.addToken(address(token));
     }
 
     function testRemoveTokenNotGovernor() public {
         vm.prank(address(1));
-        vm.expectRevert("Forbidden()");
+        vm.expectRevert("NotGovernor()");
         validator.removeToken(address(token));
     }
 

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -37,6 +37,9 @@ contract MarketplaceReplayTest is Test {
 
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(market));
+        acc.grantRole(acc.MODULE_ROLE(), address(market));
+
         token = new TestToken("Test", "TST");
         token.transfer(seller, 100 ether);
         token.transfer(buyer, 100 ether);

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -35,6 +35,9 @@ contract SubscriptionBatchTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(manager));
+        acc.grantRole(acc.MODULE_ROLE(), address(manager));
+
         token = new TestToken("Test", "TST");
     }
 

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -37,6 +37,9 @@ contract SubscriptionFlowTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(manager));
+        acc.grantRole(acc.MODULE_ROLE(), address(manager));
+
         token = new TestToken("Test", "TST");
         token.transfer(user, 10 ether);
 

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -37,6 +37,9 @@ contract SubscriptionManagerTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(manager));
+        acc.grantRole(acc.MODULE_ROLE(), address(manager));
+
         token = new TestToken("Test", "TST");
         token.transfer(user, 10 ether);
     }


### PR DESCRIPTION
## Summary
- grant FEATURE_OWNER and MODULE roles to modules in setup
- expect NotGovernor error in validator negative tests

## Testing
- `npm test` *(fails: Killed)*
- `forge test` *(fails: missing OpenZeppelin lib)*

------
https://chatgpt.com/codex/tasks/task_e_685670d3600c8323b0abb2a026756d60