### PR TITLE
Add TestHelper and update role setups

### DIFF
--- a/test/foundry/GatewayFuzz.t.sol
+++ b/test/foundry/GatewayFuzz.t.sol
@@ -7,6 +7,7 @@ import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
 import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
+import {TestHelper} from "./TestHelper.sol";
 
 contract MockValidator {
     function isAllowed(address) external pure returns (bool) { return true; }
@@ -27,7 +28,7 @@ contract GatewayFuzzTest is Test {
     function setUp() public {
         acc = new AccessControlCenter();
         acc.initialize(address(this));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        vm.startPrank(address(this));
         registry = new MockRegistry();
         registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
 
@@ -40,6 +41,13 @@ contract GatewayFuzzTest is Test {
         validator = new MockValidator();
         registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+
+        address[] memory gov;
+        address[] memory fo = new address[](1);
+        fo[0] = address(this);
+        address[] memory mods;
+        TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+        vm.stopPrank();
 
         token = new TestToken("Test", "TST");
     }

--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -8,6 +8,7 @@ import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+import {TestHelper} from "./TestHelper.sol";
 
 contract MarketplaceTest is Test {
     MockRegistry registry;
@@ -30,8 +31,6 @@ contract MarketplaceTest is Test {
         vm.startPrank(address(this));
         acc = new AccessControlCenter();
         acc.initialize(address(this));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
-        vm.stopPrank();
 
         registry = new MockRegistry();
         registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
@@ -39,6 +38,15 @@ contract MarketplaceTest is Test {
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
+
+        address[] memory gov;
+        address[] memory fo = new address[](2);
+        fo[0] = address(this);
+        fo[1] = address(market);
+        address[] memory mods = new address[](1);
+        mods[0] = address(market);
+        TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+        vm.stopPrank();
 
         token = new TestToken("Test", "TST");
         token.transfer(seller, 100 ether);

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -8,6 +8,7 @@ import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+import {TestHelper} from "./TestHelper.sol";
 
 contract MarketplaceReplayTest is Test {
     MockRegistry registry;
@@ -29,7 +30,8 @@ contract MarketplaceReplayTest is Test {
 
         acc = new AccessControlCenter();
         acc.initialize(address(this));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        vm.startPrank(address(this));
+
         registry = new MockRegistry();
         registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
         gateway = new MockPaymentGateway();
@@ -37,8 +39,15 @@ contract MarketplaceReplayTest is Test {
 
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
 
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(market));
-        acc.grantRole(acc.MODULE_ROLE(), address(market));
+        address[] memory gov;
+        address[] memory fo = new address[](2);
+        fo[0] = address(this);
+        fo[1] = address(market);
+        address[] memory mods = new address[](1);
+        mods[0] = address(market);
+        TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+
+        vm.stopPrank();
 
         token = new TestToken("Test", "TST");
         token.transfer(seller, 100 ether);

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -8,6 +8,7 @@ import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+import {TestHelper} from "./TestHelper.sol";
 
 contract SubscriptionBatchTest is Test {
     MockRegistry registry;
@@ -26,8 +27,8 @@ contract SubscriptionBatchTest is Test {
 
         acc = new AccessControlCenter();
         acc.initialize(address(this));
-        acc.grantRole(acc.AUTOMATION_ROLE(), address(this));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        vm.startPrank(address(this));
+
         registry = new MockRegistry();
         registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
         gateway = new MockPaymentGateway();
@@ -35,8 +36,18 @@ contract SubscriptionBatchTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(manager));
-        acc.grantRole(acc.MODULE_ROLE(), address(manager));
+        address[] memory gov;
+        address[] memory fo = new address[](2);
+        fo[0] = address(this);
+        fo[1] = address(manager);
+        address[] memory mods = new address[](1);
+        mods[0] = address(manager);
+        TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+        acc.grantRole(acc.AUTOMATION_ROLE(), address(this));
+
+        vm.stopPrank();
+
+        token = new TestToken("Test", "TST");
 
         token = new TestToken("Test", "TST");
     }

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -8,6 +8,7 @@ import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+import {TestHelper} from "./TestHelper.sol";
 
 contract SubscriptionFlowTest is Test {
     MockRegistry registry;
@@ -29,7 +30,8 @@ contract SubscriptionFlowTest is Test {
 
         acc = new AccessControlCenter();
         acc.initialize(address(this));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        vm.startPrank(address(this));
+
         registry = new MockRegistry();
         registry.setCoreService(keccak256(bytes("AccessControlCenter")), address(acc));
         gateway = new MockPaymentGateway();
@@ -37,8 +39,15 @@ contract SubscriptionFlowTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(manager));
-        acc.grantRole(acc.MODULE_ROLE(), address(manager));
+        address[] memory gov;
+        address[] memory fo = new address[](2);
+        fo[0] = address(this);
+        fo[1] = address(manager);
+        address[] memory mods = new address[](1);
+        mods[0] = address(manager);
+        TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+
+        vm.stopPrank();
 
         token = new TestToken("Test", "TST");
         token.transfer(user, 10 ether);

--- a/test/foundry/TestHelper.sol
+++ b/test/foundry/TestHelper.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+
+library TestHelper {
+    function setupAclAndRoles(
+        AccessControlCenter acl,
+        address[] memory governors,
+        address[] memory featureOwners,
+        address[] memory modules
+    ) internal {
+        for (uint256 i; i < governors.length; ) {
+            acl.grantRole(acl.GOVERNOR_ROLE(), governors[i]);
+            unchecked { ++i; }
+        }
+        for (uint256 i; i < featureOwners.length; ) {
+            acl.grantRole(acl.FEATURE_OWNER_ROLE(), featureOwners[i]);
+            unchecked { ++i; }
+        }
+        for (uint256 i; i < modules.length; ) {
+            acl.grantRole(acl.MODULE_ROLE(), modules[i]);
+            unchecked { ++i; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide TestHelper library to simplify ACL role setup in tests
- refactor module tests to use TestHelper

## Testing
- `forge build`
- `forge test` *(fails: AccessControlUnauthorizedAccount in several setups)*

------
https://chatgpt.com/codex/tasks/task_e_685673bec5808323a39fe9c3aca0a1b8