### PR TITLE
Add negative role tests

### DIFF
--- a/test/foundry/AccessControl.t.sol
+++ b/test/foundry/AccessControl.t.sol
@@ -8,6 +8,7 @@ import {PaymentGateway} from "contracts/core/PaymentGateway.sol";
 import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
 import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
+import "contracts/errors/Errors.sol" as Errors;
 
 contract AccessControlTest is Test {
     AccessControlCenter acc;
@@ -41,7 +42,7 @@ contract AccessControlTest is Test {
 
     function testAddTokenNotGovernor() public {
         vm.prank(address(1));
-        vm.expectRevert("NotGovernor()");
+        vm.expectRevert(Errors.NotGovernor.selector);
         validator.addToken(address(token));
     }
 
@@ -52,8 +53,9 @@ contract AccessControlTest is Test {
     }
 
     function testProcessPaymentNotFeatureOwner() public {
-        vm.prank(address(1));
-        vm.expectRevert("Forbidden()");
-        gateway.processPayment(MODULE_ID, address(token), address(1), 1 ether, "");
+        address randomUser = address(1);
+        vm.prank(randomUser);
+        vm.expectRevert(Errors.NotFeatureOwner.selector);
+        gateway.processPayment(MODULE_ID, address(token), randomUser, 1 ether, "");
     }
 }

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -9,6 +9,7 @@ import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {SignatureLib} from "contracts/lib/SignatureLib.sol";
 import {TestHelper} from "./TestHelper.sol";
+import "contracts/errors/Errors.sol" as Errors;
 
 contract SubscriptionBatchTest is Test {
     MockRegistry registry;
@@ -137,6 +138,14 @@ contract SubscriptionBatchTest is Test {
         address[] memory users = _subscribeUsers(2);
         manager.setBatchLimit(5);
         vm.expectRevert("NotDue()");
+        manager.chargeBatch(users);
+    }
+
+    function testChargeBatchNotAutomation() public {
+        address[] memory users = new address[](1);
+        users[0] = address(1);
+        vm.prank(address(1));
+        vm.expectRevert(Errors.NotAutomation.selector);
         manager.chargeBatch(users);
     }
 }


### PR DESCRIPTION
## Summary
- verify unauthorized user cannot add validator tokens
- check `processPayment` requires feature owner role
- ensure charging requires automation role

## Testing
- `forge test --match-contract AccessControlTest -vv`
- `forge test --match-contract SubscriptionBatchTest -vv` *(fails: AccessControlUnauthorizedAccount during setup)*

------
https://chatgpt.com/codex/tasks/task_e_685681911e44832385138f40f5447de0