### PR TITLE
Add coverage check script and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Forge coverage
         run: |
           forge coverage --report lcov
-          bash .github/check-coverage.sh 90
+          bash scripts/check-coverage.sh 90
 
       # 9) Hardhat coverage (using solidity-coverage)
       - name: Hardhat coverage
         run: npm run coverage
 
       # 10) Static analysis with Slither
-      - name: Slither static analysis
+      - name: Slither static
         run: slither . --fail-on-issue High

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+THRESHOLD=${1:-90}
+FILE="coverage/lcov.info"
+if [ ! -f "$FILE" ]; then
+  echo "$FILE not found" >&2
+  exit 1
+fi
+LF=$(grep -h "^LF:" "$FILE" | awk -F':' '{sum+=$2} END {print sum}')
+LH=$(grep -h "^LH:" "$FILE" | awk -F':' '{sum+=$2} END {print sum}')
+if [ -z "$LF" ] || [ -z "$LH" ] || [ "$LF" -eq 0 ]; then
+  echo "Unable to calculate coverage" >&2
+  exit 1
+fi
+COVERAGE=$(awk "BEGIN { printf(\"%d\", ($LH/$LF)*100) }")
+echo "Coverage: ${COVERAGE}%"
+if [ "$COVERAGE" -lt "$THRESHOLD" ]; then
+  echo "Coverage below ${THRESHOLD}%" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/check-coverage.sh` to enforce coverage threshold
- call new script from workflow and run Slither with fail-on-issue

## Testing
- `bash scripts/check-coverage.sh 90` with sample lcov file
- `slither . --fail-on-issue High` *(fails: unrecognized arguments)*
- `npm test` *(fails: hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685687a5549c832382cf1a24a8d0fa57