### PR TITLE
Assign roles in foundry tests

### DIFF
--- a/test/foundry/GatewayFuzz.t.sol
+++ b/test/foundry/GatewayFuzz.t.sol
@@ -38,6 +38,9 @@ contract GatewayFuzzTest is Test {
         gateway = new PaymentGateway();
         gateway.initialize(address(acc), address(registry), address(fee));
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.GOVERNOR_ROLE(), address(validator));
+
         validator = new MockValidator();
         registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));

--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -38,6 +38,8 @@ contract MarketplaceTest is Test {
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.MODULE_ROLE(), address(market));
 
         address[] memory gov;
         address[] memory fo = new address[](2);

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -38,6 +38,8 @@ contract MarketplaceReplayTest is Test {
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.MODULE_ROLE(), address(market));
 
         address[] memory gov;
         address[] memory fo = new address[](2);

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -44,6 +44,8 @@ contract SubscriptionBatchTest is Test {
         address[] memory mods = new address[](1);
         mods[0] = address(manager);
         TestHelper.setupAclAndRoles(acc, gov, fo, mods);
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.AUTOMATION_ROLE(), address(manager));
         acc.grantRole(acc.AUTOMATION_ROLE(), address(this));
 
         vm.stopPrank();

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -39,6 +39,9 @@ contract SubscriptionFlowTest is Test {
 
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.AUTOMATION_ROLE(), address(manager));
+
         address[] memory gov;
         address[] memory fo = new address[](2);
         fo[0] = address(this);

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -47,6 +47,9 @@ contract SubscriptionManagerTest is Test {
         mods[0] = address(manager);
         TestHelper.setupAclAndRoles(acc, gov, fo, mods);
 
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
+        acc.grantRole(acc.AUTOMATION_ROLE(), address(manager));
+
         vm.stopPrank();
 
         token = new TestToken("Test", "TST");


### PR DESCRIPTION
## Summary
- update Foundry tests to grant FEATURE_OWNER_ROLE, AUTOMATION_ROLE, GOVERNOR_ROLE and MODULE_ROLE where needed

## Testing
- `forge test --match-path "test/foundry/*.t.sol" -vv` *(fails: AccessControlUnauthorizedAccount in setUp)*

------
https://chatgpt.com/codex/tasks/task_e_68568b5a19a4832393437b35b9878b4b