### PR TITLE
Add helper for module roles

### DIFF
--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -45,9 +45,12 @@ contract MarketplaceTest is Test {
         validator.initialize(address(acc));
         registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
         acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(market));
-        acc.grantRole(acc.MODULE_ROLE(), address(market));
-        acc.grantRole(acc.GOVERNOR_ROLE(), address(validator));
+        TestHelper.grantRolesForModule(
+            acc,
+            address(market),
+            address(validator),
+            address(0)
+        );
 
         address[] memory gov;
         address[] memory fo = new address[](2);

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -45,9 +45,12 @@ contract MarketplaceReplayTest is Test {
         validator.initialize(address(acc));
         registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
         acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gateway));
-        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(market));
-        acc.grantRole(acc.MODULE_ROLE(), address(market));
-        acc.grantRole(acc.GOVERNOR_ROLE(), address(validator));
+        TestHelper.grantRolesForModule(
+            acc,
+            address(market),
+            address(validator),
+            address(0)
+        );
 
         address[] memory gov;
         address[] memory fo = new address[](2);

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -53,10 +53,12 @@ contract SubscriptionBatchTest is Test {
         TestHelper.setupAclAndRoles(acl, gov, fo, mods);
         acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(gateway));
         // Additional roles for subscription tests
-        acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(manager));
-        acl.grantRole(acl.MODULE_ROLE(), address(manager));
-        acl.grantRole(acl.AUTOMATION_ROLE(), automationBot);
-        acl.grantRole(acl.GOVERNOR_ROLE(), address(validator));
+        TestHelper.grantRolesForModule(
+            acl,
+            address(manager),
+            address(validator),
+            automationBot
+        );
         // Existing automation permissions
         acl.grantRole(acl.AUTOMATION_ROLE(), address(manager));
 

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -48,10 +48,12 @@ contract SubscriptionFlowTest is Test {
 
         acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(gateway));
         // Additional roles
-        acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(manager));
-        acl.grantRole(acl.MODULE_ROLE(), address(manager));
-        acl.grantRole(acl.AUTOMATION_ROLE(), automationBot);
-        acl.grantRole(acl.GOVERNOR_ROLE(), address(validator));
+        TestHelper.grantRolesForModule(
+            acl,
+            address(manager),
+            address(validator),
+            automationBot
+        );
         acl.grantRole(acl.AUTOMATION_ROLE(), address(manager));
 
         address[] memory gov;

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -57,10 +57,12 @@ contract SubscriptionManagerTest is Test {
 
         acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(gateway));
         // Additional roles for subscription manager
-        acl.grantRole(acl.FEATURE_OWNER_ROLE(), address(manager));
-        acl.grantRole(acl.MODULE_ROLE(), address(manager));
-        acl.grantRole(acl.AUTOMATION_ROLE(), automationBot);
-        acl.grantRole(acl.GOVERNOR_ROLE(), address(validator));
+        TestHelper.grantRolesForModule(
+            acl,
+            address(manager),
+            address(validator),
+            automationBot
+        );
         acl.grantRole(acl.AUTOMATION_ROLE(), address(manager));
 
         vm.stopPrank();

--- a/test/foundry/TestHelper.sol
+++ b/test/foundry/TestHelper.sol
@@ -23,4 +23,18 @@ library TestHelper {
             unchecked { ++i; }
         }
     }
+
+    function grantRolesForModule(
+        AccessControlCenter acl,
+        address moduleAddr,
+        address validatorAddr,
+        address automationBot
+    ) internal {
+        acl.grantRole(acl.FEATURE_OWNER_ROLE(), moduleAddr);
+        acl.grantRole(acl.MODULE_ROLE(), moduleAddr);
+        acl.grantRole(acl.GOVERNOR_ROLE(), validatorAddr);
+        if (automationBot != address(0)) {
+            acl.grantRole(acl.AUTOMATION_ROLE(), automationBot);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand TestHelper with grantRolesForModule
- refactor tests to use the new helper

## Testing
- `forge test -vv` *(fails: AccessControlUnauthorizedAccount errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856b641f39c8323aae030caebf29e8d