### PR TITLE
Fix test setup for admin role

### DIFF
--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -39,6 +39,8 @@ contract MarketplaceTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
+        address predicted = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), predicted);
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
         validator = new MultiValidator();
         acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), address(validator));

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -39,6 +39,8 @@ contract MarketplaceReplayTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
+        address predicted = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), predicted);
         market = new Marketplace(address(registry), address(gateway), MODULE_ID);
         validator = new MultiValidator();
         acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), address(validator));

--- a/test/foundry/SubscriptionBatch.t.sol
+++ b/test/foundry/SubscriptionBatch.t.sol
@@ -38,6 +38,8 @@ contract SubscriptionBatchTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
+        address predicted = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        acl.grantRole(acl.DEFAULT_ADMIN_ROLE(), predicted);
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
         validator = new MultiValidator();
         acl.grantRole(acl.DEFAULT_ADMIN_ROLE(), address(validator));

--- a/test/foundry/SubscriptionFlow.t.sol
+++ b/test/foundry/SubscriptionFlow.t.sol
@@ -40,6 +40,8 @@ contract SubscriptionFlowTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
+        address predicted = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        acl.grantRole(acl.DEFAULT_ADMIN_ROLE(), predicted);
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
         validator = new MultiValidator();
         acl.grantRole(acl.DEFAULT_ADMIN_ROLE(), address(validator));

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -40,6 +40,8 @@ contract SubscriptionManagerTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
+        address predicted = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        acl.grantRole(acl.DEFAULT_ADMIN_ROLE(), predicted);
         manager = new SubscriptionManager(address(registry), address(gateway), MODULE_ID);
 
         address[] memory gov;


### PR DESCRIPTION
## Summary
- fix failing Foundry tests by granting DEFAULT_ADMIN_ROLE to upcoming contract address before deploying Marketplace or SubscriptionManager

## Testing
- `forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_6856c8777d9483238060665d664d45f4