### PR TITLE
Fix Marketplace test import

### DIFF
--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -40,7 +40,7 @@ contract MarketplaceTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
-        MarketplaceForTest market = new MarketplaceForTest(
+        market = new MarketplaceForTest(
             address(registry),
             address(gateway),
             MODULE_ID

--- a/test/foundry/MarketplaceForTest.sol
+++ b/test/foundry/MarketplaceForTest.sol
@@ -25,7 +25,8 @@ contract MarketplaceForTest is Marketplace {
         bytes32 moduleId
     ) Marketplace(registry, gateway, moduleId) {
         // Вызов базового конструктора Marketplace
-        // Затем сразу назначаем тестовому контракту DEFAULT_ADMIN_ROLE
-        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        // Раньше здесь назначалась роль DEFAULT_ADMIN_ROLE для тестового
+        // контракта, но Marketplace больше не наследует AccessControl, поэтому
+        // дополнительных действий не требуется.
     }
 }

--- a/test/foundry/MarketplaceReplay.t.sol
+++ b/test/foundry/MarketplaceReplay.t.sol
@@ -39,12 +39,11 @@ contract MarketplaceReplayTest is Test {
         gateway = new MockPaymentGateway();
         registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
 
-        MarketplaceForTest market = new MarketplaceForTest(
+        market = new MarketplaceForTest(
             address(registry),
             address(gateway),
             MODULE_ID
         );
-        market = new MarketplaceForTest();
         validator = new MultiValidator();
         acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), address(validator));
         validator.initialize(address(acc));


### PR DESCRIPTION
## Summary
- rename test helper MarketPlaceForTest.sol to MarketplaceForTest.sol so test imports resolve
- remove outdated _setupRole call
- fix variable shadowing in test setup

## Testing
- `npx hardhat clean`
- `npx hardhat compile`

------
https://chatgpt.com/codex/tasks/task_e_68570997e47883239f09c689a7ac9a6b