### PR TITLE
Fix hardhat test runner

### DIFF
--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,15 +1,19 @@
 // test/test-runner.js
 
-const { spawnSync } = require('child_process');
+const { spawn } = require('child_process');
+const path = require('path');
 
-// на Windows нужно «npm.cmd», на *nix — «npm»
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+// Путь к локальному бинарнику Hardhat для кросс-платформенности
+const bin = path.resolve(__dirname, '../node_modules/.bin/hardhat');
+const cmd = process.platform === 'win32' ? `${bin}.cmd` : bin;
 
-// запускаем определённый в package.json скрипт test:hardhat
-const result = spawnSync(
-    npmCmd,
-    ['run', 'test:hardhat'],
-    { stdio: 'inherit' }
-);
+const args = ['test', ...process.argv.slice(2)];
 
-process.exit(result.status);
+const child = spawn(cmd, args, { stdio: 'inherit' });
+
+child.on('error', err => {
+    console.error('Failed to run hardhat tests:', err);
+    process.exit(1);
+});
+
+child.on('exit', code => process.exit(code ?? 1));

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -16,8 +16,8 @@ let result;
 if (fs.existsSync(binPath)) {
     result = spawnSync(binPath, args, { stdio: 'inherit' });
 } else {
-    const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    result = spawnSync(npxCmd, ['hardhat', ...args], { stdio: 'inherit' });
+    console.error('Hardhat binary not found. Did you run "npm install"?');
+    process.exit(1);
 }
 
 if (result.error) {


### PR DESCRIPTION
## Summary
- revert to spawning the local Hardhat binary
- handle spawn errors so failure exits with non-zero code

## Testing
- `node test/test-runner.js --help`
- `npx hardhat test test/hardhat/contestFee.ts`

------
https://chatgpt.com/codex/tasks/task_e_68581e7222a4832399fceffa9819cbb2