### PR TITLE
Fix factory address prediction in tests

### DIFF
--- a/test/hardhat/contestFee.ts
+++ b/test/hardhat/contestFee.ts
@@ -26,9 +26,10 @@ async function deployFactory() {
   const Validator = await ethers.getContractFactory("MultiValidator");
   const validatorLogic = await Validator.deploy();
 
+  // predict the factory address after the upcoming grantRole tx
   const predictedFactory = ethers.getCreateAddress({
     from: deployer.address,
-    nonce: await deployer.getNonce(),
+    nonce: (await deployer.getNonce()) + 1,
   });
   await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
 

--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -26,9 +26,10 @@ async function deployFactory() {
   const Validator = await ethers.getContractFactory("MultiValidator");
   const validatorLogic = await Validator.deploy();
 
+  // predict the factory address after the upcoming grantRole tx
   const predictedFactory = ethers.getCreateAddress({
     from: deployer.address,
-    nonce: await deployer.getNonce(),
+    nonce: (await deployer.getNonce()) + 1,
   });
   await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
 

--- a/test/hardhat/prizeAssignment.ts
+++ b/test/hardhat/prizeAssignment.ts
@@ -26,9 +26,10 @@ async function deployFactory() {
   const Validator = await ethers.getContractFactory("MultiValidator");
   const validatorLogic = await Validator.deploy();
 
+  // predict the factory address after the upcoming grantRole tx
   const predictedFactory = ethers.getCreateAddress({
     from: deployer.address,
-    nonce: await deployer.getNonce(),
+    nonce: (await deployer.getNonce()) + 1,
   });
   await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
 


### PR DESCRIPTION
## Summary
- ensure predicted factory address accounts for the grantRole transaction in tests

## Testing
- `npm test` *(fails: InitFailed errors)*

------
https://chatgpt.com/codex/tasks/task_e_68584bd6ba888323ae60d11e788febbb