### PR TITLE
Refactor test deployment helpers

### DIFF
--- a/test/hardhat/contestFee.ts
+++ b/test/hardhat/contestFee.ts
@@ -1,75 +1,11 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-
-function predictCloneAddress(impl: string, salt: string, deployer: string) {
-  const prefix = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
-  const suffix = "5af43d82803e903d91602b57fd5bf3";
-  const creationCode = prefix + impl.slice(2) + suffix;
-  const initHash = ethers.keccak256(creationCode);
-  return ethers.getCreate2Address(deployer, salt, initHash);
-}
-
-async function deployFactory() {
-  const [deployer] = await ethers.getSigners();
-  const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("USD Coin", "USDC");
-
-  const ACL = await ethers.getContractFactory("AccessControlCenter");
-  const acl = await ACL.deploy();
-  await acl.initialize(deployer.address);
-  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
-  await acl.grantRole(FACTORY_ADMIN, deployer.address);
-  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), deployer.address);
-
-  const Registry = await ethers.getContractFactory("MockRegistry");
-  const registry = await Registry.deploy();
-  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
-
-  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
-  const gateway = await Gateway.deploy();
-
-  const PriceFeed = await ethers.getContractFactory("MockPriceFeed");
-  const priceFeed = await PriceFeed.deploy();
-
-  const Validator = await ethers.getContractFactory("MultiValidator");
-  const validatorLogic = await Validator.deploy();
-
-  // predict the factory address after the upcoming grantRole tx
-  const predictedFactory = ethers.getCreateAddress({
-    from: deployer.address,
-    nonce: (await deployer.getNonce()) + 1,
-  });
-
-  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  const salt = ethers.keccak256(
-    ethers.solidityPacked([
-      "string",
-      "bytes32",
-      "address",
-    ], ["Validator", moduleId, predictedFactory])
-  );
-  const predictedValidator = predictCloneAddress(
-    await validatorLogic.getAddress(),
-    salt,
-    predictedFactory
-  );
-
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedValidator);
-
-  const Factory = await ethers.getContractFactory("ContestFactory");
-  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
-
-  await factory.setPriceFeed(await priceFeed.getAddress());
-  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
-
-  return { factory, token, priceFeed, registry, gateway };
-}
+import { deployContestFactory } from "./helpers";
 
 describe("ContestFactory fee", function () {
   it("uses price feed for commission", async function () {
     const [creator] = await ethers.getSigners();
-    const { factory, token, priceFeed, gateway } = await deployFactory();
+    const { factory, token, priceFeed, gateway } = await deployContestFactory();
 
     const params = {
       judges: [] as string[],

--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -1,70 +1,6 @@
 import { expect } from "chai";
 import { ethers, network } from "hardhat";
-
-function predictCloneAddress(impl: string, salt: string, deployer: string) {
-  const prefix = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
-  const suffix = "5af43d82803e903d91602b57fd5bf3";
-  const creationCode = prefix + impl.slice(2) + suffix;
-  const initHash = ethers.keccak256(creationCode);
-  return ethers.getCreate2Address(deployer, salt, initHash);
-}
-
-async function deployFactory() {
-  const [deployer] = await ethers.getSigners();
-  const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("USD Coin", "USDC");
-
-  const ACL = await ethers.getContractFactory("AccessControlCenter");
-  const acl = await ACL.deploy();
-  await acl.initialize(deployer.address);
-  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
-  await acl.grantRole(FACTORY_ADMIN, deployer.address);
-  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), deployer.address);
-
-  const Registry = await ethers.getContractFactory("MockRegistry");
-  const registry = await Registry.deploy();
-  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
-
-  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
-  const gateway = await Gateway.deploy();
-
-  const PriceFeed = await ethers.getContractFactory("MockPriceFeed");
-  const priceFeed = await PriceFeed.deploy();
-
-  const Validator = await ethers.getContractFactory("MultiValidator");
-  const validatorLogic = await Validator.deploy();
-
-  // predict the factory address after the upcoming grantRole tx
-  const predictedFactory = ethers.getCreateAddress({
-    from: deployer.address,
-    nonce: (await deployer.getNonce()) + 1,
-  });
-
-  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  const salt = ethers.keccak256(
-    ethers.solidityPacked([
-      "string",
-      "bytes32",
-      "address",
-    ], ["Validator", moduleId, predictedFactory])
-  );
-  const predictedValidator = predictCloneAddress(
-    await validatorLogic.getAddress(),
-    salt,
-    predictedFactory
-  );
-
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedValidator);
-
-  const Factory = await ethers.getContractFactory("ContestFactory");
-  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
-
-  await factory.setPriceFeed(await priceFeed.getAddress());
-  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
-
-  return { factory, token, priceFeed, registry, gateway };
-}
+import { deployContestFactory } from "./helpers";
 
 async function allowToken(factory: any, registry: any, token: any) {
   const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
@@ -84,7 +20,7 @@ function getCreatedContest(rc: any) {
 describe("Contest finalize", function () {
   it("handles multiple prizes", async function () {
     const [creator, a, b, c] = await ethers.getSigners();
-    const { factory, token, priceFeed, registry, gateway } = await deployFactory();
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
 
     await allowToken(factory, registry, token);
 
@@ -122,7 +58,7 @@ describe("Contest finalize", function () {
 
   it("reverts on second finalize", async function () {
     const [creator, a, b, c] = await ethers.getSigners();
-    const { factory, token, priceFeed, registry, gateway } = await deployFactory();
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
 
     await allowToken(factory, registry, token);
 
@@ -150,7 +86,7 @@ describe("Contest finalize", function () {
 
   it("reverts on wrong winners count", async function () {
     const [creator, a, b, c] = await ethers.getSigners();
-    const { factory, token, priceFeed, registry, gateway } = await deployFactory();
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));
@@ -180,7 +116,7 @@ describe("Contest finalize", function () {
     const [creator, a] = await ethers.getSigners();
     await network.provider.send("hardhat_setBalance", [creator.address, "0x21e19e0c9bab2400000"]);
 
-    const { factory, token, priceFeed, registry, gateway } = await deployFactory();
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -1,66 +1,9 @@
 import { expect } from "chai";
 import { ethers, network } from "hardhat";
-
-function predictCloneAddress(impl: string, salt: string, deployer: string) {
-  const prefix = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
-  const suffix = "5af43d82803e903d91602b57fd5bf3";
-  const creationCode = prefix + impl.slice(2) + suffix;
-  const initHash = ethers.keccak256(creationCode);
-  return ethers.getCreate2Address(deployer, salt, initHash);
-}
+import { deployContestFactory } from "./helpers";
 
 async function deployCore() {
-  const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("USD Coin", "USDC");
-
-  const ACL = await ethers.getContractFactory("AccessControlCenter");
-  const acl = await ACL.deploy();
-  await acl.initialize((await ethers.getSigners())[0].address);
-  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
-  await acl.grantRole(FACTORY_ADMIN, (await ethers.getSigners())[0].address);
-  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), (await ethers.getSigners())[0].address);
-
-  const Registry = await ethers.getContractFactory("MockRegistry");
-  const registry = await Registry.deploy();
-  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
-
-  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
-  const gateway = await Gateway.deploy();
-
-  const PriceFeed = await ethers.getContractFactory("ChainlinkPriceFeed");
-  const priceFeed = await PriceFeed.deploy();
-
-  const Validator = await ethers.getContractFactory("MultiValidator");
-  const validatorLogic = await Validator.deploy();
-
-  const predictedFactory = ethers.getCreateAddress({
-    from: (await ethers.getSigners())[0].address,
-    nonce: (await (await ethers.getSigners())[0].getNonce()) + 1,
-  });
-  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  const salt = ethers.keccak256(
-    ethers.solidityPacked([
-      "string",
-      "bytes32",
-      "address",
-    ], ["Validator", moduleId, predictedFactory])
-  );
-  const predictedValidator = predictCloneAddress(
-    await validatorLogic.getAddress(),
-    salt,
-    predictedFactory
-  );
-
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedValidator);
-
-  const Factory = await ethers.getContractFactory("ContestFactory");
-  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
-
-  await factory.setPriceFeed(await priceFeed.getAddress());
-  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
-
-  return { factory, token, priceFeed, registry, gateway };
+  return await deployContestFactory("ChainlinkPriceFeed");
 }
 
 describe("fork e2e", function () {

--- a/test/hardhat/gateway.ts
+++ b/test/hardhat/gateway.ts
@@ -29,6 +29,6 @@ describe("PaymentGateway access", function () {
     const MODULE_ID = ethers.keccak256(ethers.toUtf8Bytes("Core"));
     await expect(
       gateway.connect(user).processPayment(MODULE_ID, await token.getAddress(), user.address, ethers.parseEther("1"), "0x")
-    ).to.be.revertedWithCustomError(gateway, "Forbidden");
+    ).to.be.revertedWithCustomError(gateway, "NotFeatureOwner");
   });
 });

--- a/test/hardhat/helpers.ts
+++ b/test/hardhat/helpers.ts
@@ -1,0 +1,68 @@
+import { ethers } from "hardhat";
+
+export function predictCloneAddress(impl: string, salt: string, deployer: string) {
+  const prefix = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
+  const suffix = "5af43d82803e903d91602b57fd5bf3";
+  const creationCode = prefix + impl.slice(2) + suffix;
+  const initHash = ethers.keccak256(creationCode);
+  return ethers.getCreate2Address(deployer, salt, initHash);
+}
+
+export async function deployContestFactory(priceFeedName: string = "MockPriceFeed") {
+  const [deployer] = await ethers.getSigners();
+  const Token = await ethers.getContractFactory("TestToken");
+  const token = await Token.deploy("USD Coin", "USDC");
+
+  const ACL = await ethers.getContractFactory("AccessControlCenter");
+  const acl = await ACL.deploy();
+  await acl.initialize(deployer.address);
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  await acl.grantRole(FACTORY_ADMIN, deployer.address);
+  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), deployer.address);
+
+  const Registry = await ethers.getContractFactory("MockRegistry");
+  const registry = await Registry.deploy();
+  await registry.setCoreService(
+    ethers.keccak256(Buffer.from("AccessControlCenter")),
+    await acl.getAddress()
+  );
+
+  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
+  const gateway = await Gateway.deploy();
+
+  const PriceFeed = await ethers.getContractFactory(priceFeedName);
+  const priceFeed = await PriceFeed.deploy();
+
+  const Validator = await ethers.getContractFactory("MultiValidator");
+  const validatorLogic = await Validator.deploy();
+
+  const nextNonce = await deployer.getNonce();
+  const predictedFactory = ethers.getCreateAddress({
+    from: deployer.address,
+    nonce: nextNonce + 2,
+  });
+  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+  const salt = ethers.keccak256(
+    ethers.solidityPacked(["string", "bytes32", "address"], ["Validator", moduleId, predictedFactory])
+  );
+  const predictedValidator = predictCloneAddress(
+    await validatorLogic.getAddress(),
+    salt,
+    predictedFactory
+  );
+
+  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
+  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedValidator);
+
+  const Factory = await ethers.getContractFactory("ContestFactory");
+  const factory = await Factory.deploy(
+    await registry.getAddress(),
+    await gateway.getAddress(),
+    await validatorLogic.getAddress()
+  );
+
+  await factory.setPriceFeed(await priceFeed.getAddress());
+  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
+
+  return { factory, token, priceFeed, registry, gateway, acl };
+}

--- a/test/hardhat/prizeAssignment.ts
+++ b/test/hardhat/prizeAssignment.ts
@@ -1,75 +1,11 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-
-function predictCloneAddress(impl: string, salt: string, deployer: string) {
-  const prefix = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
-  const suffix = "5af43d82803e903d91602b57fd5bf3";
-  const creationCode = prefix + impl.slice(2) + suffix;
-  const initHash = ethers.keccak256(creationCode);
-  return ethers.getCreate2Address(deployer, salt, initHash);
-}
-
-async function deployFactory() {
-  const [deployer] = await ethers.getSigners();
-  const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("USD Coin", "USDC");
-
-  const ACL = await ethers.getContractFactory("AccessControlCenter");
-  const acl = await ACL.deploy();
-  await acl.initialize(deployer.address);
-  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
-  await acl.grantRole(FACTORY_ADMIN, deployer.address);
-  await acl.grantRole(await acl.FEATURE_OWNER_ROLE(), deployer.address);
-
-  const Registry = await ethers.getContractFactory("MockRegistry");
-  const registry = await Registry.deploy();
-  await registry.setCoreService(ethers.keccak256(Buffer.from("AccessControlCenter")), await acl.getAddress());
-
-  const Gateway = await ethers.getContractFactory("MockPaymentGateway");
-  const gateway = await Gateway.deploy();
-
-  const PriceFeed = await ethers.getContractFactory("MockPriceFeed");
-  const priceFeed = await PriceFeed.deploy();
-
-  const Validator = await ethers.getContractFactory("MultiValidator");
-  const validatorLogic = await Validator.deploy();
-
-  // predict the factory address after the upcoming grantRole tx
-  const predictedFactory = ethers.getCreateAddress({
-    from: deployer.address,
-    nonce: (await deployer.getNonce()) + 1,
-  });
-
-  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  const salt = ethers.keccak256(
-    ethers.solidityPacked([
-      "string",
-      "bytes32",
-      "address",
-    ], ["Validator", moduleId, predictedFactory])
-  );
-  const predictedValidator = predictCloneAddress(
-    await validatorLogic.getAddress(),
-    salt,
-    predictedFactory
-  );
-
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedFactory);
-  await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedValidator);
-
-  const Factory = await ethers.getContractFactory("ContestFactory");
-  const factory = await Factory.deploy(await registry.getAddress(), await gateway.getAddress(), await validatorLogic.getAddress());
-
-  await factory.setPriceFeed(await priceFeed.getAddress());
-  await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
-
-  return { factory, token, priceFeed, registry, gateway };
-}
+import { deployContestFactory } from "./helpers";
 
 describe("PrizeAssigned event", function () {
   it("emits for non monetary prize", async function () {
     const [creator, winner] = await ethers.getSigners();
-    const { factory, token, priceFeed, gateway } = await deployFactory();
+    const { factory, token, priceFeed, gateway } = await deployContestFactory();
 
     const params = {
       judges: [] as string[],

--- a/test/hardhat/subscription.ts
+++ b/test/hardhat/subscription.ts
@@ -23,8 +23,18 @@ describe("SubscriptionManager permit", function () {
     const gateway = await Gateway.deploy();
 
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const nextNonce = await owner.getNonce();
+    const predictedManager = ethers.getCreateAddress({
+      from: owner.address,
+      nonce: nextNonce + 1,
+    });
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedManager);
     const Manager = await ethers.getContractFactory("SubscriptionManager");
-    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+    const manager = await Manager.deploy(
+      await registry.getAddress(),
+      await gateway.getAddress(),
+      moduleId
+    );
 
     const plan = {
       chainIds: [31337n],
@@ -96,8 +106,18 @@ describe("SubscriptionManager permit", function () {
     const gateway = await Gateway.deploy();
 
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const nextNonce = await owner.getNonce();
+    const predictedManager = ethers.getCreateAddress({
+      from: owner.address,
+      nonce: nextNonce + 1,
+    });
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedManager);
     const Manager = await ethers.getContractFactory("SubscriptionManager");
-    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+    const manager = await Manager.deploy(
+      await registry.getAddress(),
+      await gateway.getAddress(),
+      moduleId
+    );
 
     const plan = {
       chainIds: [31337n],
@@ -172,8 +192,18 @@ describe("SubscriptionManager unsubscribe", function () {
     const gateway = await Gateway.deploy();
 
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const nextNonce = await owner.getNonce();
+    const predictedManager = ethers.getCreateAddress({
+      from: owner.address,
+      nonce: nextNonce + 1,
+    });
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedManager);
     const Manager = await ethers.getContractFactory("SubscriptionManager");
-    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+    const manager = await Manager.deploy(
+      await registry.getAddress(),
+      await gateway.getAddress(),
+      moduleId
+    );
 
     const plan = {
       chainIds: [31337n],
@@ -227,8 +257,18 @@ describe("SubscriptionManager batch charge", function () {
     const gateway = await Gateway.deploy();
 
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const nextNonce = await owner.getNonce();
+    const predictedManager = ethers.getCreateAddress({
+      from: owner.address,
+      nonce: nextNonce + 1,
+    });
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedManager);
     const Manager = await ethers.getContractFactory("SubscriptionManager");
-    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+    const manager = await Manager.deploy(
+      await registry.getAddress(),
+      await gateway.getAddress(),
+      moduleId
+    );
 
     const plan = {
       chainIds: [31337n],
@@ -288,8 +328,18 @@ describe("SubscriptionManager batch charge", function () {
     const gateway = await Gateway.deploy();
 
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
+    const nextNonce = await owner.getNonce();
+    const predictedManager = ethers.getCreateAddress({
+      from: owner.address,
+      nonce: nextNonce + 1,
+    });
+    await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), predictedManager);
     const Manager = await ethers.getContractFactory("SubscriptionManager");
-    const manager = await Manager.deploy(await registry.getAddress(), await gateway.getAddress(), moduleId);
+    const manager = await Manager.deploy(
+      await registry.getAddress(),
+      await gateway.getAddress(),
+      moduleId
+    );
 
     const plan = {
       chainIds: [31337n],

--- a/test/hardhat/validator.ts
+++ b/test/hardhat/validator.ts
@@ -46,6 +46,6 @@ describe("MultiValidator", function () {
 
     await expect(
       val.connect(attacker).addToken("0x2000000000000000000000000000000000000002")
-    ).to.be.revertedWithCustomError(val, "Forbidden");
+    ).to.be.revertedWithCustomError(val, "NotGovernor");
   });
 });


### PR DESCRIPTION
## Summary
- add `deployContestFactory` helper to share contract setup
- remove duplicated deployment code in contest tests
- fix custom error names in gateway and validator tests
- adjust subscription tests to grant roles to predicted addresses

## Testing
- `npm test --silent` *(fails: InvalidSignature and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68587220779c8323be1e0f14ca627676