### PR TITLE
Fix ContestFactory fee test

### DIFF
--- a/contracts/mocks/MockFeeManager.sol
+++ b/contracts/mocks/MockFeeManager.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
+contract MockFeeManager {
+    using SafeERC20 for IERC20;
+
+    address public lastToken;
+    uint256 public lastAmount;
+
+    function depositFee(bytes32, address token, uint256 amount) external {
+        lastToken = token;
+        lastAmount = amount;
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+    }
+}

--- a/contracts/mocks/MockPaymentGateway.sol
+++ b/contracts/mocks/MockPaymentGateway.sol
@@ -8,6 +8,16 @@ import '../interfaces/IGateway.sol';
 contract MockPaymentGateway is IGateway {
     using SafeERC20 for IERC20;
 
+    address public feeManagerAddress;
+
+    function setFeeManager(address manager) external {
+        feeManagerAddress = manager;
+    }
+
+    function feeManager() external view returns (address) {
+        return feeManagerAddress;
+    }
+
     function processPayment(
         bytes32,
         address token,

--- a/test/hardhat/helpers.ts
+++ b/test/hardhat/helpers.ts
@@ -30,6 +30,10 @@ export async function deployContestFactory(priceFeedName: string = "MockPriceFee
   const Gateway = await ethers.getContractFactory("MockPaymentGateway");
   const gateway = await Gateway.deploy();
 
+  const FeeManager = await ethers.getContractFactory("MockFeeManager");
+  const feeManager = await FeeManager.deploy();
+  await gateway.setFeeManager(await feeManager.getAddress());
+
   const PriceFeed = await ethers.getContractFactory(priceFeedName);
   const priceFeed = await PriceFeed.deploy();
 
@@ -64,5 +68,5 @@ export async function deployContestFactory(priceFeedName: string = "MockPriceFee
   await factory.setPriceFeed(await priceFeed.getAddress());
   await factory.setUsdFeeBounds(ethers.parseEther("5"), ethers.parseEther("10"));
 
-  return { factory, token, priceFeed, registry, gateway, acl };
+  return { factory, token, priceFeed, registry, gateway, acl, feeManager };
 }


### PR DESCRIPTION
## Summary
- implement a basic MockFeeManager contract
- expose feeManager in MockPaymentGateway
- wire the mock fee manager in hardhat helper for factory deployment

## Testing
- `npx hardhat test test/hardhat/contestFee.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685909fcdc7483239c50530a2a98f668