### PR TITLE
Fix tests

### DIFF
--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -4,7 +4,9 @@ import { deployContestFactory } from "./helpers";
 
 async function allowToken(factory: any, registry: any, token: any) {
   const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  const validatorAddr = await registry.getModuleService(moduleId, "Validator");
+  const serviceId = ethers.keccak256(ethers.toUtf8Bytes("Validator"));
+  const validatorAddr = await registry.getModuleService(moduleId, serviceId);
+  await network.provider.send("hardhat_setBalance", [await factory.getAddress(), "0x21e19e0c9bab2400000"]);
   await network.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
   const factorySigner = await ethers.getSigner(await factory.getAddress());
   const validator = await ethers.getContractAt("MultiValidator", validatorAddr);

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -24,7 +24,8 @@ describe("fork e2e", function () {
 
     // allow token via validator
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-    const validatorAddr = await registry.getModuleService(moduleId, "Validator");
+    const serviceId = ethers.keccak256(ethers.toUtf8Bytes("Validator"));
+    const validatorAddr = await registry.getModuleService(moduleId, serviceId);
     await network.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
     const factorySigner = await ethers.getSigner(await factory.getAddress());
     const validator = await ethers.getContractAt("MultiValidator", validatorAddr);

--- a/test/hardhat/prizeAssignment.ts
+++ b/test/hardhat/prizeAssignment.ts
@@ -5,7 +5,7 @@ import { deployContestFactory } from "./helpers";
 describe("PrizeAssigned event", function () {
   it("emits for non monetary prize", async function () {
     const [creator, winner] = await ethers.getSigners();
-    const { factory, token, priceFeed, gateway } = await deployContestFactory();
+    const { factory, token, priceFeed, gateway, registry } = await deployContestFactory();
 
     const params = {
       judges: [] as string[],
@@ -31,6 +31,10 @@ describe("PrizeAssigned event", function () {
     const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr = ev?.args[1];
     const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+
+    const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+    await registry.setModuleServiceAlias(moduleId, "EventRouter", winner.address);
+    await registry.setModuleServiceAlias(moduleId, "NFTManager", winner.address);
 
     const finalizeTx = await esc.finalize([winner.address]);
     const receipt = await finalizeTx.wait();

--- a/test/hardhat/subscription.ts
+++ b/test/hardhat/subscription.ts
@@ -1,6 +1,18 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
+const planTypes = {
+  Plan: [
+    { name: "chainIds", type: "uint256[]" },
+    { name: "price", type: "uint256" },
+    { name: "period", type: "uint256" },
+    { name: "token", type: "address" },
+    { name: "merchant", type: "address" },
+    { name: "salt", type: "uint256" },
+    { name: "expiry", type: "uint64" },
+  ],
+};
+
 describe("SubscriptionManager permit", function () {
   it("allows subscribe with permit", async function () {
     const [owner, merchant] = await ethers.getSigners();
@@ -47,7 +59,11 @@ describe("SubscriptionManager permit", function () {
     } as const;
 
     const planHash = await manager.hashPlan(plan);
-    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+    const sigMerchant = await merchant.signTypedData(
+      { chainId: 31337, verifyingContract: await manager.getAddress() },
+      planTypes,
+      plan
+    );
 
     const nonce = await token.nonces(owner.address);
     const deadline = (await ethers.provider.getBlock("latest")).timestamp + 1000;
@@ -130,7 +146,11 @@ describe("SubscriptionManager permit", function () {
     } as const;
 
     const planHash = await manager.hashPlan(plan);
-    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+    const sigMerchant = await merchant.signTypedData(
+      { chainId: 31337, verifyingContract: await manager.getAddress() },
+      planTypes,
+      plan
+    );
 
     const nonce = await token.nonces(owner.address);
     const deadline = (await ethers.provider.getBlock("latest")).timestamp + 1000;
@@ -216,7 +236,11 @@ describe("SubscriptionManager unsubscribe", function () {
     } as const;
 
     const planHash = await manager.hashPlan(plan);
-    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+    const sigMerchant = await merchant.signTypedData(
+      { chainId: 31337, verifyingContract: await manager.getAddress() },
+      planTypes,
+      plan
+    );
 
     await token.approve(await gateway.getAddress(), plan.price);
     await manager.subscribe(plan, sigMerchant, "0x");
@@ -281,7 +305,11 @@ describe("SubscriptionManager batch charge", function () {
     } as const;
 
     const planHash = await manager.hashPlan(plan);
-    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+    const sigMerchant = await merchant.signTypedData(
+      { chainId: 31337, verifyingContract: await manager.getAddress() },
+      planTypes,
+      plan
+    );
 
     for (const u of users) {
       await token.transfer(u.address, ethers.parseEther("10"));
@@ -352,7 +380,11 @@ describe("SubscriptionManager batch charge", function () {
     } as const;
 
     const planHash = await manager.hashPlan(plan);
-    const sigMerchant = await merchant.signMessage(ethers.getBytes(planHash));
+    const sigMerchant = await merchant.signTypedData(
+      { chainId: 31337, verifyingContract: await manager.getAddress() },
+      planTypes,
+      plan
+    );
 
     await token.transfer(user.address, ethers.parseEther("10"));
     await token.connect(user).approve(await gateway.getAddress(), plan.price);


### PR DESCRIPTION
## Summary
- compute validator service ids using keccak256
- sign subscription plans with EIP-712 typed data
- fund impersonated factory for validator setup
- register dummy services for prize assignment test

## Testing
- `npm test` *(fails: 9 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68591664da288323b13e79dfa9640a89