### PR TITLE
Fix EIP712 hashing for plans and listings

### DIFF
--- a/contracts/lib/SignatureLib.sol
+++ b/contracts/lib/SignatureLib.sol
@@ -42,7 +42,7 @@ library SignatureLib {
     }
 
     function hashListing(Listing calldata l) internal pure returns (bytes32) {
-        bytes32 chainHash = keccak256(abi.encode(l.chainIds.length, l.chainIds));
+        bytes32 chainHash = keccak256(abi.encodePacked(l.chainIds));
         return keccak256(abi.encode(LISTING_TYPEHASH, chainHash, l.token, l.price, l.sku, l.seller, l.salt, l.expiry));
     }
 
@@ -51,7 +51,7 @@ library SignatureLib {
     }
 
     function hashPlan(Plan calldata p) internal pure returns (bytes32) {
-        bytes32 chainHash = keccak256(abi.encode(p.chainIds.length, p.chainIds));
+        bytes32 chainHash = keccak256(abi.encodePacked(p.chainIds));
         return
             keccak256(abi.encode(PLAN_TYPEHASH, chainHash, p.price, p.period, p.token, p.merchant, p.salt, p.expiry));
     }


### PR DESCRIPTION
## Summary
- correct EIP712 array hashing in `SignatureLib`

## Testing
- `npm test` *(fails: Contest finalize; meta transaction; PrizeAssigned; SubscriptionManager batch charge)*

------
https://chatgpt.com/codex/tasks/task_e_685922eadd2083239d2902c0524bad45