### PR TITLE
Add mocks and update tests

### DIFF
--- a/contracts/mocks/MockEventRouter.sol
+++ b/contracts/mocks/MockEventRouter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+contract MockEventRouter {
+    enum EventKind {
+        ContestFinalized
+    }
+
+    function route(EventKind /* kind */, bytes calldata /* payload */) external {}
+}

--- a/contracts/mocks/MockNFTManager.sol
+++ b/contracts/mocks/MockNFTManager.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+contract MockNFTManager {
+    function mintBatch(address[] calldata /*recipients*/, string[] calldata /*uris*/, bool /*soulbound*/) external {}
+}

--- a/test/hardhat/prizeAssignment.ts
+++ b/test/hardhat/prizeAssignment.ts
@@ -32,9 +32,14 @@ describe("PrizeAssigned event", function () {
     const contestAddr = ev?.args[1];
     const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
 
+    const EventRouter = await ethers.getContractFactory("MockEventRouter");
+    const router = await EventRouter.deploy();
+    const NFT = await ethers.getContractFactory("MockNFTManager");
+    const nft = await NFT.deploy();
+
     const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-    await registry.setModuleServiceAlias(moduleId, "EventRouter", winner.address);
-    await registry.setModuleServiceAlias(moduleId, "NFTManager", winner.address);
+    await registry.setModuleServiceAlias(moduleId, "EventRouter", await router.getAddress());
+    await registry.setModuleServiceAlias(moduleId, "NFTManager", await nft.getAddress());
 
     const finalizeTx = await esc.finalize([winner.address]);
     const receipt = await finalizeTx.wait();

--- a/test/hardhat/subscription.ts
+++ b/test/hardhat/subscription.ts
@@ -313,7 +313,9 @@ describe("SubscriptionManager batch charge", function () {
 
     for (const u of users) {
       await token.transfer(u.address, ethers.parseEther("10"));
-      await token.connect(u).approve(await gateway.getAddress(), plan.price);
+      await token
+        .connect(u)
+        .approve(await gateway.getAddress(), ethers.MaxUint256);
       await manager.connect(u).subscribe(plan, sigMerchant, "0x");
     }
 


### PR DESCRIPTION
## Summary
- add MockEventRouter and MockNFTManager contracts
- use these mocks in `prizeAssignment` test
- give unlimited token allowance in `subscription` batch charge test

## Testing
- `npx hardhat compile`
- `npx hardhat test test/hardhat/prizeAssignment.ts` *(fails: Transaction reverted without a reason string)*

------
https://chatgpt.com/codex/tasks/task_e_68592c67c66c8323994de7a459f27b59