### PR TITLE
Fix finalize test signer

### DIFF
--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -48,7 +48,11 @@ describe("Contest finalize", function () {
     const balA0 = await token.balanceOf(a.address);
     const balB0 = await token.balanceOf(b.address);
 
-    const finalizeTx = await esc.finalize([a.address, b.address, c.address]);
+    const finalizeTx = await esc.connect(creator).finalize([
+      a.address,
+      b.address,
+      c.address,
+    ]);
     await expect(finalizeTx).to.emit(esc, "MonetaryPrizePaid").withArgs(a.address, ethers.parseEther("10"));
     await expect(finalizeTx).to.emit(esc, "MonetaryPrizePaid").withArgs(b.address, ethers.parseEther("5"));
     await expect(finalizeTx).to.emit(esc, "PromoPrizeIssued").withArgs(2, c.address, "ipfs://promo");
@@ -83,11 +87,10 @@ describe("Contest finalize", function () {
     const contestAddr = getCreatedContest(rc);
     const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
 
-    await esc.finalize([a.address, b.address, c.address]);
-    await expect(esc.finalize([a.address, b.address, c.address])).to.be.revertedWithCustomError(
-      esc,
-      "ContestAlreadyFinalized"
-    );
+    await esc.connect(creator).finalize([a.address, b.address, c.address]);
+    await expect(
+      esc.connect(creator).finalize([a.address, b.address, c.address])
+    ).to.be.revertedWithCustomError(esc, "ContestAlreadyFinalized");
   });
 
   it("reverts on wrong winners count", async function () {


### PR DESCRIPTION
## Summary
- ensure ContestEscrow.finalize uses the creator signer in tests

## Testing
- `npm test` *(fails: VM Exception while processing transaction: reverted with an unrecognized custom error)*

------
https://chatgpt.com/codex/tasks/task_e_68594ac4b9f48323bb02f9508d0759d2