### PR TITLE
Fix contest prize deposits

### DIFF
--- a/test/hardhat/contestDeposit.ts
+++ b/test/hardhat/contestDeposit.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deployContestFactory } from "./helpers";
+
+async function allowToken(factory: any, registry: any, token: any) {
+  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+  const serviceId = ethers.keccak256(ethers.toUtf8Bytes("Validator"));
+  const validatorAddr = await registry.getModuleService(moduleId, serviceId);
+  await ethers.provider.send("hardhat_setBalance", [await factory.getAddress(), "0x21e19e0c9bab2400000"]);
+  await ethers.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
+  const factorySigner = await ethers.getSigner(await factory.getAddress());
+  const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+  await validator.connect(factorySigner).addToken(await token.getAddress());
+  await ethers.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
+}
+
+describe("createContest deposits prizes", function () {
+  it("deposits prize amounts to escrow", async function () {
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
+    await allowToken(factory, registry, token);
+
+    await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("100"));
+    await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
+
+    const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
+    const prizes = [
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("3"), distribution: 0, uri: "" },
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("2"), distribution: 0, uri: "" }
+    ];
+
+    const tx = await factory.createCustomContest(prizes, params);
+    const rc = await tx.wait();
+    const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
+    const contestAddr = ev?.args[1];
+    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+
+    const expected = ethers.parseEther("5") + (await esc.gasPool());
+    expect(await token.balanceOf(contestAddr)).to.equal(expected);
+  });
+});

--- a/test/hardhat/contestFee.ts
+++ b/test/hardhat/contestFee.ts
@@ -15,6 +15,7 @@ describe("ContestFactory fee", function () {
 
     // Approve factory to pull tokens via gateway mock
   await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+  await token.approve(await factory.getAddress(), ethers.parseEther("100"));
 
     // test price 0.95 USD
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("0.95"));

--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -27,6 +27,7 @@ describe("Contest finalize", function () {
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("1000"));
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
 
     const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
@@ -73,6 +74,7 @@ describe("Contest finalize", function () {
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("1000"));
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
 
     const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
@@ -99,6 +101,7 @@ describe("Contest finalize", function () {
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("1000"));
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
 
     const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
@@ -129,6 +132,7 @@ describe("Contest finalize", function () {
     await allowToken(factory, registry, token);
 
     await token.approve(await gateway.getAddress(), ethers.parseEther("1000"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("1000"));
     await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
 
     const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -34,6 +34,7 @@ describe("fork e2e", function () {
 
     // approve tokens for gateway
     await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("100"));
 
     const params = {
       judges: [] as string[],

--- a/test/hardhat/metaTx.spec.ts
+++ b/test/hardhat/metaTx.spec.ts
@@ -20,6 +20,7 @@ describe("meta transaction", function () {
     const Gateway = await ethers.getContractFactory("PaymentGateway");
     const gateway = await Gateway.deploy();
     await gateway.initialize(await acc.getAddress(), await registry.getAddress(), await fee.getAddress());
+    await (await acc.grantRole(await acc.FEATURE_OWNER_ROLE(), await gateway.getAddress())).wait();
 
     const Validator = await ethers.getContractFactory("MultiValidator");
     const validator = await Validator.deploy();
@@ -38,9 +39,9 @@ describe("meta transaction", function () {
     const Forwarder = await ethers.getContractFactory("MockForwarder");
     const forwarder = await Forwarder.deploy(await acc.getAddress());
 
-    await acc.grantRole(await acc.FEATURE_OWNER_ROLE(), forwarder.getAddress());
-    await acc.grantRole(await acc.RELAYER_ROLE(), forwarder.getAddress());
-    await acc.grantRole(await acc.RELAYER_ROLE(), relayer.address);
+    await (await acc.grantRole(await acc.FEATURE_OWNER_ROLE(), forwarder.getAddress())).wait();
+    await (await acc.grantRole(await acc.RELAYER_ROLE(), forwarder.getAddress())).wait();
+    await (await acc.grantRole(await acc.RELAYER_ROLE(), relayer.address)).wait();
 
     const data = gateway.interface.encodeFunctionData("processPayment", [
       MODULE_ID,


### PR DESCRIPTION
## Summary
- transfer prizes directly from creator to escrow when contest is created
- adjust tests for new approval flow
- cover prize deposit on contest creation

## Testing
- `npm test` *(fails: VM Exception while processing transaction)*

------
https://chatgpt.com/codex/tasks/task_e_68595314d7688323bbb547389e11f360