### PR TITLE
Fix TS types in tests and scripts

### DIFF
--- a/scripts/showcase-all.ts
+++ b/scripts/showcase-all.ts
@@ -30,11 +30,11 @@ async function main() {
 
   console.log("Deploying feature modules...");
   const Validator = await ethers.getContractFactory("MultiValidator");
-  const marketValidator = await Validator.deploy();
+  const marketValidator: any = await Validator.deploy();
   await marketValidator.initialize(await acl.getAddress());
   await marketValidator.addToken(await token.getAddress());
 
-  const subValidator = await Validator.deploy();
+  const subValidator: any = await Validator.deploy();
   await subValidator.initialize(await acl.getAddress());
   await subValidator.addToken(await token.getAddress());
 
@@ -89,7 +89,7 @@ async function main() {
   const rc = await tx.wait();
   const created = rc?.logs.find(l => l.fragment && l.fragment.name === "ContestCreated");
   const contestAddr = created?.args[1];
-  const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+  const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
   await gateway.connect(winner); // just to silence ts
   await esc.finalize([winner.address, deployer.address]);
   console.log("Contest finalized, winner balance:", (await token.balanceOf(winner.address)).toString());

--- a/scripts/showcase.ts
+++ b/scripts/showcase.ts
@@ -34,7 +34,7 @@ async function allowToken(factory: any, registry: any, token: any) {
   const validatorAddr = await registry.getModuleService(moduleId, "Validator");
   await network.provider.request({ method: "hardhat_impersonateAccount", params: [await factory.getAddress()] });
   const signer = await ethers.getSigner(await factory.getAddress());
-  const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+  const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
   await validator.connect(signer).addToken(await token.getAddress());
   await network.provider.request({ method: "hardhat_stopImpersonatingAccount", params: [await factory.getAddress()] });
 }
@@ -62,7 +62,7 @@ async function main() {
   const tx = await factory.createCustomContest(prizes, params);
   const rc = await tx.wait();
   const contestAddr = getCreatedContest(rc);
-  const escrow = await ethers.getContractAt("ContestEscrow", contestAddr);
+  const escrow = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
   console.log("Contest escrow:", contestAddr);
 
   const finalizeTx = await escrow.finalize([addr1.address, addr2.address, addr3.address]);

--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -49,7 +49,7 @@ async function allowToken(factory: any, registry: any, token: any) {
     params: [await factory.getAddress()],
   });
   const signer = await ethers.getSigner(await factory.getAddress());
-  const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+  const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
   await validator.connect(signer).addToken(await token.getAddress());
   await network.provider.request({
     method: "hardhat_stopImpersonatingAccount",
@@ -97,7 +97,7 @@ async function massFinalize(count = 1000) {
 
   console.log("Finalizing contests...");
   for (const addr of contests) {
-    const esc = await ethers.getContractAt("ContestEscrow", addr);
+    const esc = (await ethers.getContractAt("ContestEscrow", addr)) as any;
     const poolBefore = await esc.gasPool();
     await (await esc.finalize([creator.address])).wait();
     const poolAfter = await esc.gasPool();

--- a/test/hardhat/contestDeposit.ts
+++ b/test/hardhat/contestDeposit.ts
@@ -9,7 +9,7 @@ async function allowToken(factory: any, registry: any, token: any) {
   await ethers.provider.send("hardhat_setBalance", [await factory.getAddress(), "0x21e19e0c9bab2400000"]);
   await ethers.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
   const factorySigner = await ethers.getSigner(await factory.getAddress());
-  const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+  const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
   await validator.connect(factorySigner).addToken(await token.getAddress());
   await ethers.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
 }
@@ -33,7 +33,7 @@ describe("createContest deposits prizes", function () {
     const rc = await tx.wait();
     const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr = ev?.args[1];
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     const expected = ethers.parseEther("5") + (await esc.gasPool());
     expect(await token.balanceOf(contestAddr)).to.equal(expected);

--- a/test/hardhat/contestFee.ts
+++ b/test/hardhat/contestFee.ts
@@ -23,7 +23,7 @@ describe("ContestFactory fee", function () {
     let rc = await tx.wait();
     let ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr1 = ev?.args[1];
-    const esc1 = await ethers.getContractAt("ContestEscrow", contestAddr1);
+    const esc1 = (await ethers.getContractAt("ContestEscrow", contestAddr1)) as any;
     let fee1 = await esc1.commissionFee();
     expect(fee1).to.be.gte(ethers.parseEther("5"));
     expect(fee1).to.be.lte(ethers.parseEther("10"));
@@ -34,7 +34,7 @@ describe("ContestFactory fee", function () {
     rc = await tx.wait();
     ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr2 = ev?.args[1];
-    const esc2 = await ethers.getContractAt("ContestEscrow", contestAddr2);
+    const esc2 = (await ethers.getContractAt("ContestEscrow", contestAddr2)) as any;
     let fee2 = await esc2.commissionFee();
     expect(fee2).to.be.gte(ethers.parseEther("5"));
     expect(fee2).to.be.lte(ethers.parseEther("10"));

--- a/test/hardhat/contestFinalize.ts
+++ b/test/hardhat/contestFinalize.ts
@@ -9,7 +9,7 @@ async function allowToken(factory: any, registry: any, token: any) {
   await network.provider.send("hardhat_setBalance", [await factory.getAddress(), "0x21e19e0c9bab2400000"]);
   await network.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
   const factorySigner = await ethers.getSigner(await factory.getAddress());
-  const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+  const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
   await validator.connect(factorySigner).addToken(await token.getAddress());
   await network.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
 }
@@ -40,7 +40,7 @@ describe("Contest finalize", function () {
     const tx = await factory.createCustomContest(prizes, params);
     const rc = await tx.wait();
     const contestAddr = getCreatedContest(rc);
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     const expectedBalance =
       ethers.parseEther("15") + (await esc.gasPool());
@@ -87,7 +87,7 @@ describe("Contest finalize", function () {
     const tx = await factory.createCustomContest(prizes, params);
     const rc = await tx.wait();
     const contestAddr = getCreatedContest(rc);
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     await esc.connect(creator).finalize([a.address, b.address, c.address]);
     await expect(
@@ -114,13 +114,13 @@ describe("Contest finalize", function () {
     const tx = await factory.createCustomContest(prizes, params);
     const rc = await tx.wait();
     const contestAddr = getCreatedContest(rc);
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     await expect(esc.finalize([a.address, b.address])).to.be.revertedWithCustomError(esc, "WrongWinnersCount");
   });
 
   it("refunds gas to creator", async function () {
-    if (!network.config.forking?.url) {
+    if (!(network.config as any).forking?.url) {
       console.log("Skipping: not a forked network");
       this.skip();
     }
@@ -143,7 +143,7 @@ describe("Contest finalize", function () {
     const tx = await factory.createCustomContest(prizes, params);
     const rc = await tx.wait();
     const contestAddr = getCreatedContest(rc);
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     const balBefore = await token.balanceOf(creator.address);
     const gasPoolBefore = await esc.gasPool();

--- a/test/hardhat/e2e.spec.ts
+++ b/test/hardhat/e2e.spec.ts
@@ -8,7 +8,7 @@ async function deployCore() {
 
 describe("fork e2e", function () {
   it("deploys contest and finalizes prizes", async function () {
-    if (!network.config.forking?.url) {
+    if (!(network.config as any).forking?.url) {
       console.log("Skipping: not a forked network");
       this.skip();
     }
@@ -28,7 +28,7 @@ describe("fork e2e", function () {
     const validatorAddr = await registry.getModuleService(moduleId, serviceId);
     await network.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
     const factorySigner = await ethers.getSigner(await factory.getAddress());
-    const validator = await ethers.getContractAt("MultiValidator", validatorAddr);
+    const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
     await validator.connect(factorySigner).addToken(await token.getAddress());
     await network.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
 
@@ -56,7 +56,7 @@ describe("fork e2e", function () {
     const rc = await tx.wait();
     const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr = ev?.args[1];
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     const fee = await esc.commissionFee();
     expect(fee).to.be.gte(ethers.parseEther("5"));

--- a/test/hardhat/metaTx.spec.ts
+++ b/test/hardhat/metaTx.spec.ts
@@ -23,7 +23,7 @@ describe("meta transaction", function () {
     await (await acc.grantRole(await acc.FEATURE_OWNER_ROLE(), await gateway.getAddress())).wait();
 
     const Validator = await ethers.getContractFactory("MultiValidator");
-    const validator = await Validator.deploy();
+    const validator: any = await Validator.deploy();
     await acc.grantRole(await acc.DEFAULT_ADMIN_ROLE(), await validator.getAddress());
     await validator.initialize(await acc.getAddress());
 

--- a/test/hardhat/prizeAssignment.ts
+++ b/test/hardhat/prizeAssignment.ts
@@ -30,7 +30,7 @@ describe("PrizeAssigned event", function () {
     const rc = await tx.wait();
     const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
     const contestAddr = ev?.args[1];
-    const esc = await ethers.getContractAt("ContestEscrow", contestAddr);
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
 
     const EventRouter = await ethers.getContractFactory("MockEventRouter");
     const router = await EventRouter.deploy();

--- a/test/hardhat/validator.ts
+++ b/test/hardhat/validator.ts
@@ -10,7 +10,7 @@ describe("MultiValidator", function () {
     await acl.initialize(admin.address);
 
     const Validator = await ethers.getContractFactory("MultiValidator");
-    const val = await Validator.deploy();
+    const val: any = await Validator.deploy();
 
     // allow validator to grant roles during initialize
     await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), await val.getAddress());
@@ -39,7 +39,7 @@ describe("MultiValidator", function () {
     await acl.initialize(admin.address);
 
     const Validator = await ethers.getContractFactory("MultiValidator");
-    const val = await Validator.deploy();
+    const val: any = await Validator.deploy();
 
     await acl.grantRole(await acl.DEFAULT_ADMIN_ROLE(), await val.getAddress());
     await val.initialize(await acl.getAddress());


### PR DESCRIPTION
## Summary
- cast hardhat contract instances to `any` where Typechain types aren't available
- guard Hardhat network forking checks with `any` cast

## Testing
- `npx hardhat test` *(fails: needs to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685977ff78c0832390189d075f96a084