### PR TITLE
Fix contest funding check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
    npx hardhat node
    npm run deploy:local
    ```
+   Before calling `createCustomContest` the creator must approve the
+   `ContestFactory` contract to transfer the entire prize pool on their behalf.
 4. Run tests:
    ```bash
    npm test

--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -60,20 +60,8 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
         commissionToken = _commissionToken;
         commissionFee = _commissionFee;
         gasPool = _initialGasPool;
-        for (uint i = 0; i < _prizes.length; i++) {
+        for (uint256 i = 0; i < _prizes.length; i++) {
             prizes.push(_prizes[i]);
-            if (msg.sender == _creator && _prizes[i].prizeType == PrizeType.MONETARY && _prizes[i].amount > 0) {
-                IERC20 token = IERC20(_prizes[i].token);
-                uint256 balBefore = token.balanceOf(address(this));
-                if (balBefore < _prizes[i].amount) {
-                    uint256 missing = _prizes[i].amount - balBefore;
-                    try token.transferFrom(_creator, address(this), missing) {} catch {
-                        revert ContestFundingMissing();
-                    }
-                    uint256 balAfter = token.balanceOf(address(this));
-                    if (balAfter - balBefore == 0) revert ContestFundingMissing();
-                }
-            }
         }
         // store judges & metadata if needed
     }
@@ -107,6 +95,9 @@ contract ContestEscrow is IContestEscrow, ReentrancyGuard {
         for (uint256 i = start; i < len; ) {
             PrizeInfo memory p = prizes[i];
             if (p.amount > 0) {
+                if (IERC20(p.token).balanceOf(address(this)) < p.amount) {
+                    revert ContestFundingMissing();
+                }
                 uint256 amount = p.distribution == 0 ? p.amount : _computeDescending(p.amount, uint8(i));
                 IERC20(p.token).safeTransfer(winners[i], amount);
                 emit MonetaryPrizePaid(winners[i], amount);

--- a/test/hardhat/directDeploy.ts
+++ b/test/hardhat/directDeploy.ts
@@ -5,15 +5,23 @@ import { deployContestFactory } from "./helpers";
 // simple test for direct deploy without prefunding
 
 describe("direct deploy fails if no tokens", function () {
-  it("reverts constructor", async function () {
-    const [creator] = await ethers.getSigners();
+  it("reverts finalize due to missing funding", async function () {
+    const [creator, winner] = await ethers.getSigners();
     const { registry, token } = await deployContestFactory();
     const prizes = [
       { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("1"), distribution: 0, uri: "" }
     ];
     const Escrow = await ethers.getContractFactory("ContestEscrow");
-    await expect(
-      Escrow.deploy(await registry.getAddress(), creator.address, prizes, await token.getAddress(), 0, 0, [], "0x")
-    ).to.be.revertedWithCustomError(Escrow, "ContestFundingMissing");
+    const esc = await Escrow.deploy(
+      await registry.getAddress(),
+      creator.address,
+      prizes,
+      await token.getAddress(),
+      0,
+      0,
+      [],
+      "0x"
+    );
+    await expect(esc.finalize([winner.address])).to.be.revertedWithCustomError(esc, "ContestFundingMissing");
   });
 });

--- a/test/hardhat/escrowFunded.ts
+++ b/test/hardhat/escrowFunded.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deployContestFactory } from "./helpers";
+
+async function allowToken(factory: any, registry: any, token: any) {
+  const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+  const serviceId = ethers.keccak256(ethers.toUtf8Bytes("Validator"));
+  const validatorAddr = await registry.getModuleService(moduleId, serviceId);
+  await ethers.provider.send("hardhat_setBalance", [await factory.getAddress(), "0x21e19e0c9bab2400000"]);
+  await ethers.provider.send("hardhat_impersonateAccount", [await factory.getAddress()]);
+  const factorySigner = await ethers.getSigner(await factory.getAddress());
+  const validator = (await ethers.getContractAt("MultiValidator", validatorAddr)) as any;
+  await validator.connect(factorySigner).addToken(await token.getAddress());
+  await ethers.provider.send("hardhat_stopImpersonatingAccount", [await factory.getAddress()]);
+}
+
+describe("escrow funded", function () {
+  it("holds prize pool after deployment", async function () {
+    const { factory, token, priceFeed, registry, gateway } = await deployContestFactory();
+    await allowToken(factory, registry, token);
+
+    await token.approve(await gateway.getAddress(), ethers.parseEther("100"));
+    await token.approve(await factory.getAddress(), ethers.parseEther("100"));
+    await priceFeed.setPrice(await token.getAddress(), ethers.parseEther("1"));
+
+    const params = { judges: [] as string[], metadata: "0x", commissionToken: await token.getAddress() };
+    const prizes = [
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("3"), distribution: 0, uri: "" },
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("2"), distribution: 0, uri: "" }
+    ];
+
+    const tx = await factory.createCustomContest(prizes, params);
+    const rc = await tx.wait();
+    const ev = rc?.logs.find((l: any) => l.fragment && l.fragment.name === "ContestCreated");
+    const contestAddr = ev?.args[1];
+    const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
+
+    const expected = ethers.parseEther("5") + (await esc.gasPool());
+    expect(await token.balanceOf(contestAddr)).to.equal(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- simplify ContestEscrow constructor and move prize transfer logic solely to the factory
- add funding check during `finalize`
- update direct deployment test for new behaviour
- add `escrow funded` unit test
- document factory allowance requirement

## Testing
- `npm test` *(fails: Contest finalize tests revert)*
- `npx slither .` *(not run: package missing)*
- `npx solhint 'contracts/**/*.sol'` *(not run: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_685983cf1ae0832389dc784cb8a08044