### PR TITLE
Rename contests module to v2 default

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import '../../../core/Registry.sol';
-import '../../../core/EventRouter.sol';
-import '../../../shared/NFTManager.sol';
-import '../../../errors/Errors.sol';
-import '../shared/PrizeInfo.sol';
-import '../../../interfaces/CoreDefs.sol';
+import '../../core/Registry.sol';
+import '../../core/EventRouter.sol';
+import '../../shared/NFTManager.sol';
+import '../../errors/Errors.sol';
+import './shared/PrizeInfo.sol';
+import '../../interfaces/CoreDefs.sol';
 import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 
-/// @title ContestEscrowV2
-contract ContestEscrowV2 is ReentrancyGuard {
+/// @title ContestEscrow
+contract ContestEscrow is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     Registry public immutable registry;

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import '../../../interfaces/core/IRegistry.sol';
-import '../../../core/AccessControlCenter.sol';
-import '../../../errors/Errors.sol';
-import '../shared/PrizeInfo.sol';
-import './ContestEscrowV2.sol';
+import '../../interfaces/core/IRegistry.sol';
+import '../../core/AccessControlCenter.sol';
+import '../../errors/Errors.sol';
+import './shared/PrizeInfo.sol';
+import './ContestEscrow.sol';
 import './interfaces/IContestValidator.sol';
-import '../../../interfaces/CoreDefs.sol';
+import '../../interfaces/CoreDefs.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 
-/// @title ContestFactoryV2
+/// @title ContestFactory
 /// @notice Deploys new contest escrows and handles initial funding.
-contract ContestFactoryV2 {
+contract ContestFactory {
     using SafeERC20 for IERC20;
 
     event ContestCreated(address indexed creator, address contest);
@@ -52,7 +52,7 @@ contract ContestFactoryV2 {
         }
 
         // deploy escrow
-        ContestEscrowV2 esc = new ContestEscrowV2(msg.sender, _prizes, address(registry), 0, feeManager);
+        ContestEscrow esc = new ContestEscrow(msg.sender, _prizes, address(registry), 0, feeManager);
         escrow = address(esc);
 
         // transfer tokens to escrow, fail-fast on missing amounts

--- a/contracts/modules/contests/ContestValidator.sol
+++ b/contracts/modules/contests/ContestValidator.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import '../../core/AccessControlCenter.sol';
+import '../../interfaces/core/IMultiValidator.sol';
+import '../../errors/Errors.sol';
+import './shared/PrizeInfo.sol';
+import './interfaces/IContestValidator.sol';
+
+/// @title ContestValidator
+/// @notice Basic validator for Contest prizes
+contract ContestValidator is IContestValidator {
+    AccessControlCenter public access;
+    IMultiValidator public tokenValidator;
+
+    constructor(address _access, address _tokenValidator) {
+        access = AccessControlCenter(_access);
+        tokenValidator = IMultiValidator(_tokenValidator);
+    }
+
+    modifier onlyGovernor() {
+        if (!access.hasRole(access.GOVERNOR_ROLE(), msg.sender)) revert NotGovernor();
+        _;
+    }
+
+    function setTokenValidator(address newValidator) external onlyGovernor {
+        if (newValidator == address(0)) revert ZeroAddress();
+        tokenValidator = IMultiValidator(newValidator);
+    }
+
+    // --- IContestValidator ---
+
+    function validatePrize(PrizeInfo calldata prize) external view override {
+        if (prize.prizeType == PrizeType.MONETARY) {
+            if (prize.amount == 0) revert InvalidPrizeData();
+            if (!isTokenAllowed(prize.token)) revert NotAllowedToken();
+            if (!isDistributionValid(prize.amount, prize.distribution)) revert InvalidDistribution();
+        } else if (prize.prizeType == PrizeType.PROMO) {
+            if (prize.amount != 0 || prize.token != address(0)) revert InvalidPrizeData();
+        } else {
+            revert InvalidPrizeData();
+        }
+    }
+
+    function isTokenAllowed(address token) public view override returns (bool) {
+        return tokenValidator.isAllowed(token);
+    }
+
+    function isDistributionValid(uint256 amount, uint8 distribution) public pure override returns (bool) {
+        if (distribution == 0) {
+            return amount > 0;
+        }
+        if (distribution == 1) {
+            return amount > 0;
+        }
+        return false;
+    }
+}

--- a/contracts/modules/contests/interfaces/IContestValidator.sol
+++ b/contracts/modules/contests/interfaces/IContestValidator.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import '../../shared/PrizeInfo.sol';
+import '../shared/PrizeInfo.sol';
 
-/// @notice Validator plugin for Contest V2
+/// @notice Validator plugin for Contests
 interface IContestValidator {
     /// @dev Validate a single prize slot. Revert on violation.
     function validatePrize(PrizeInfo calldata prize) external view;

--- a/docs/contest.md
+++ b/docs/contest.md
@@ -1,6 +1,6 @@
-# Contest Module V2
+# Contest Module
 
-This document summarizes the design for version 2 of the contest module.
+This document summarizes the design of the contest module.
 
 ## Overview
 
@@ -72,7 +72,7 @@ error ContestAlreadyFinalized();
 error WrongWinnersCount();
 ```
 
-## Improvements in V2
+## Improvements
 
 - **Fail-fast** — missing token transfers are caught during `createContest`.
 - **Minimal surface** — no `transferFrom` calls after deployment and no external calls before `finalized`.


### PR DESCRIPTION
## Summary
- move contest contracts out of the `v2` folder
- rename contracts to `ContestFactory`, `ContestEscrow`, and `ContestValidator`
- move `IContestValidator` interface and fix imports
- rename `docs/contest-v2.md` to `contest.md`

## Testing
- `npm test` *(fails: Cannot find module 'test/test-runner.js')*

------
https://chatgpt.com/codex/tasks/task_e_685c5ee5b648832398a515e36eb6d8d2