### PR TITLE
Fix contest factory and escrow issues

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -70,8 +70,8 @@ contract ContestEscrow is ReentrancyGuard {
         uint256 end = start + maxWinnersPerTx;
         if (end > prizes.length) end = prizes.length;
 
-        bool willFinalize = end == prizes.length;
-        if (willFinalize) {
+        // mark as finalized before any external calls
+        if (end == prizes.length) {
             finalized = true;
         }
 

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -45,10 +45,11 @@ contract ContestFactory {
             }
         }
 
-        // basic sanity check for promo slots
+        // basic sanity check for promo slots and zero-amount prizes
         for (uint256 i = 0; i < _prizes.length; i++) {
             PrizeInfo calldata p = _prizes[i];
             if (p.prizeType == PrizeType.PROMO && p.token != address(0)) revert InvalidPrizeData();
+            if (p.amount == 0 && p.token != address(0)) revert InvalidPrizeData();
         }
 
         // deploy escrow


### PR DESCRIPTION
## Summary
- enforce zero token for zero-amount prizes in ContestFactory
- mark contest finalized before payouts begin

## Testing
- `npm run compile` *(fails: need to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685c689d9aa08323b149db00b02cd3d1