### PR TITLE
Improve contest security

### DIFF
--- a/contracts/modules/contests/ContestEscrow.sol
+++ b/contracts/modules/contests/ContestEscrow.sol
@@ -57,7 +57,11 @@ contract ContestEscrow is ReentrancyGuard {
         }
     }
 
-    function finalize(address[] calldata _winners) external nonReentrant onlyCreator {
+    function finalize(address[] calldata _winners, uint256 priorityCap)
+        external
+        nonReentrant
+        onlyCreator
+    {
         if (finalized) revert ContestAlreadyFinalized();
         if (_winners.length != prizes.length) revert WrongWinnersCount();
 
@@ -78,7 +82,9 @@ contract ContestEscrow is ReentrancyGuard {
         for (uint256 i = start; i < end; ) {
             PrizeInfo memory p = prizes[i];
             if (p.prizeType == PrizeType.MONETARY) {
-                uint256 amount = p.distribution == 0 ? p.amount : _computeDescending(p.amount, uint8(i));
+                uint256 amount =
+                    p.distribution == 0 ? p.amount : _computeDescending(p.amount, uint8(i));
+                if (IERC20(p.token).balanceOf(address(this)) < amount) revert InsufficientBalance();
                 IERC20(p.token).safeTransfer(winners[i], amount);
                 emit MonetaryPrizePaid(winners[i], amount);
             } else {
@@ -92,7 +98,8 @@ contract ContestEscrow is ReentrancyGuard {
 
         processedWinners = end;
         uint256 gasUsed = gasStart - gasleft();
-        uint256 refund = gasUsed * tx.gasprice;
+        uint256 price = tx.gasprice < block.basefee + priorityCap ? tx.gasprice : block.basefee + priorityCap;
+        uint256 refund = gasUsed * price;
         if (refund > gasPool) refund = gasPool;
         if (refund > 0) {
             gasPool -= refund;

--- a/contracts/modules/contests/ContestFactory.sol
+++ b/contracts/modules/contests/ContestFactory.sol
@@ -36,7 +36,7 @@ contract ContestFactory {
     function createContest(
         PrizeInfo[] calldata _prizes,
         bytes calldata /* metadata */
-    ) external returns (address escrow) {
+    ) external onlyGovernor returns (address escrow) {
         // validate prizes via plugin if available
         address validator = registry.getModuleService(CoreDefs.CONTEST_MODULE_ID, CoreDefs.SERVICE_VALIDATOR);
         if (validator != address(0)) {

--- a/docs/contest.md
+++ b/docs/contest.md
@@ -32,7 +32,7 @@ constructor(
 
 /// @notice Distributes all prizes to winners once.
 /// @dev Reverts WrongWinnersCount or ContestAlreadyFinalized.
-function finalize(address[] calldata winners) external;
+function finalize(address[] calldata winners, uint256 priorityCap) external;
 
 /// @notice Cancel the contest before finalization.
 function cancel() external; // only creator

--- a/scripts/showcase-all.ts
+++ b/scripts/showcase-all.ts
@@ -91,7 +91,7 @@ async function main() {
   const contestAddr = created?.args[1];
   const esc = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
   await gateway.connect(winner); // just to silence ts
-  await esc.finalize([winner.address, deployer.address]);
+  await esc.finalize([winner.address, deployer.address], 0n);
   console.log("Contest finalized, winner balance:", (await token.balanceOf(winner.address)).toString());
 }
 

--- a/scripts/showcase.ts
+++ b/scripts/showcase.ts
@@ -65,7 +65,7 @@ async function main() {
   const escrow = (await ethers.getContractAt("ContestEscrow", contestAddr)) as any;
   console.log("Contest escrow:", contestAddr);
 
-  const finalizeTx = await escrow.finalize([addr1.address, addr2.address, addr3.address]);
+  const finalizeTx = await escrow.finalize([addr1.address, addr2.address, addr3.address], 0n);
   const receipt = await finalizeTx.wait();
 
   console.log("Finalize events:");

--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -99,7 +99,7 @@ async function massFinalize(count = 1000) {
   for (const addr of contests) {
     const esc = (await ethers.getContractAt("ContestEscrow", addr)) as any;
     const poolBefore = await esc.gasPool();
-    await (await esc.finalize([creator.address])).wait();
+    await (await esc.finalize([creator.address], 0n)).wait();
     const poolAfter = await esc.gasPool();
     console.log(`Finalized ${addr} gasPool ${poolBefore} -> ${poolAfter}`);
   }


### PR DESCRIPTION
## Summary
- add governor check to `createContest`
- validate escrow balances before payouts
- use priority-based gas refund formula
- update examples and docs

## Testing
- `npm test` *(fails: Cannot find module `test/test-runner.js`)*
- `npm run compile` *(fails: needs packages `hardhat`)*

------
https://chatgpt.com/codex/tasks/task_e_685c95d426848323bf084c30d90cf641