### PR TITLE
Add Foundry tests and drop extraneous submodules

### DIFF
--- a/contracts/shared/CloneFactory.sol
+++ b/contracts/shared/CloneFactory.sol
@@ -19,4 +19,10 @@ abstract contract CloneFactory {
     function _predict(address implementation, bytes32 salt) internal view returns (address) {
         return Clones.predictDeterministicAddress(implementation, salt, address(this));
     }
+
+    function _revert(bytes memory returndata) internal pure {
+        assembly {
+            revert(add(returndata, 0x20), mload(returndata))
+        }
+    }
 }

--- a/test/foundry/AccessControlCenter.t.sol
+++ b/test/foundry/AccessControlCenter.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/access/IAccessControl.sol";
+
+contract AccessControlCenterTest is Test {
+    AccessControlCenter internal acc;
+    address internal admin = address(0xA11CE);
+    address internal other = address(0xBEEF);
+
+    function setUp() public {
+        AccessControlCenter impl = new AccessControlCenter();
+        bytes memory data = abi.encodeCall(AccessControlCenter.initialize, admin);
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        acc = AccessControlCenter(address(proxy));
+    }
+
+    function testGrantAndRevokeRole() public {
+        bytes32 role = acc.RELAYER_ROLE();
+        vm.prank(admin);
+        acc.grantRole(role, other);
+        assertTrue(acc.hasRole(role, other));
+
+        vm.prank(admin);
+        acc.revokeRole(role, other);
+        assertFalse(acc.hasRole(role, other));
+    }
+
+    function testUnauthorizedUpgrade() public {
+        AccessControlCenter newImpl = new AccessControlCenter();
+        vm.prank(other);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                other,
+                acc.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        vm.prank(other);
+        acc.upgradeToAndCall(address(newImpl), bytes(""));
+    }
+
+    function testUpgradeOnImplementationFails() public {
+        AccessControlCenter impl = new AccessControlCenter();
+        impl.initialize(admin);
+        AccessControlCenter newImpl = new AccessControlCenter();
+        vm.prank(admin);
+        vm.expectRevert(UUPSUpgradeable.UUPSUnauthorizedCallContext.selector);
+        impl.upgradeToAndCall(address(newImpl), bytes(""));
+    }
+}
+

--- a/test/foundry/CloneFactory.t.sol
+++ b/test/foundry/CloneFactory.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "contracts/shared/CloneFactory.sol";
+
+contract DummyTemplate {
+    uint256 public value;
+    error InitFailed();
+
+    function init(uint256 v) external {
+        if (v == 0) revert InitFailed();
+        value = v;
+    }
+}
+
+contract TestCloneFactory is CloneFactory {
+    event Cloned(address indexed implementation, address indexed instance);
+
+    function clone(address impl, bytes32 salt, bytes memory initData) external returns (address) {
+        address inst = _clone(impl, salt, initData);
+        emit Cloned(impl, inst);
+        return inst;
+    }
+
+    function predict(address impl, bytes32 salt) external view returns (address) {
+        return _predict(impl, salt);
+    }
+}
+
+contract CloneFactoryTest is Test {
+    TestCloneFactory internal factory;
+    DummyTemplate internal template;
+
+    function setUp() public {
+        factory = new TestCloneFactory();
+        template = new DummyTemplate();
+    }
+
+    function testCloneSuccess() public {
+        bytes32 salt = keccak256("one");
+        bytes memory initData = abi.encodeCall(DummyTemplate.init, (42));
+        address predicted = factory.predict(address(template), salt);
+
+        vm.expectEmit(true, true, false, false);
+        emit TestCloneFactory.Cloned(address(template), predicted);
+        address cloneAddr = factory.clone(address(template), salt, initData);
+        assertEq(cloneAddr, predicted);
+        assertEq(DummyTemplate(cloneAddr).value(), 42);
+        assertEq(cloneAddr.code.length, 45);
+    }
+
+    function testInitFailure() public {
+        bytes32 salt = keccak256("two");
+        bytes memory initData = abi.encodeCall(DummyTemplate.init, (0));
+        vm.expectRevert(DummyTemplate.InitFailed.selector);
+        factory.clone(address(template), salt, initData);
+    }
+
+    function testDifferentSaltsProduceDifferentAddresses() public {
+        bytes32 salt1 = bytes32(uint256(1));
+        bytes32 salt2 = bytes32(uint256(2));
+        address c1 = factory.clone(address(template), salt1, abi.encodeCall(DummyTemplate.init, (1)));
+        address c2 = factory.clone(address(template), salt2, abi.encodeCall(DummyTemplate.init, (2)));
+        assertTrue(c1 != c2);
+    }
+}
+

--- a/test/foundry/ContestEscrow.t.sol
+++ b/test/foundry/ContestEscrow.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {ContestEscrow} from "contracts/modules/contests/ContestEscrow.sol";
+import {PrizeInfo, PrizeType} from "contracts/modules/contests/shared/PrizeInfo.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract ContestEscrowTest is Test {
+    ContestEscrow internal escrow;
+    TestToken internal token;
+    address internal creator = address(0xCAFE);
+    address internal w1 = address(0x1);
+    address internal w2 = address(0x2);
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        PrizeInfo[] memory prizes = new PrizeInfo[](2);
+        prizes[0] = PrizeInfo({prizeType: PrizeType.MONETARY, token: address(token), amount: 100 ether, distribution: 0, uri: ""});
+        prizes[1] = PrizeInfo({prizeType: PrizeType.MONETARY, token: address(token), amount: 50 ether, distribution: 0, uri: ""});
+        MockRegistry reg = new MockRegistry();
+        escrow = new ContestEscrow(creator, prizes, address(reg), 0, address(token), block.timestamp + 1 days);
+        token.transfer(address(escrow), 150 ether);
+    }
+
+    function testFinalizeDistributesPrizes() public {
+        address[] memory winners = new address[](2);
+        winners[0] = w1;
+        winners[1] = w2;
+        vm.prank(creator);
+        escrow.finalize(winners, 0, 0);
+        assertEq(token.balanceOf(w1), 100 ether);
+        assertEq(token.balanceOf(w2), 50 ether);
+        assertTrue(escrow.finalized());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement Foundry tests for `AccessControlCenter`, `CloneFactory` and `ContestEscrow`
- add `_revert` helper in `CloneFactory` to bubble init errors
- remove `forge-std` and OpenZeppelin library submodules

## Testing
- `forge test -vv`


------
https://chatgpt.com/codex/tasks/task_e_685dc63533508323a5765095b5f3f159