### PR TITLE
Add Foundry tests for core modules

### DIFF
--- a/test/foundry/CoreFeeManager.t.sol
+++ b/test/foundry/CoreFeeManager.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {NotFeatureOwner} from "contracts/errors/Errors.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract CoreFeeManagerTest is Test {
+    CoreFeeManager internal fee;
+    AccessControlCenter internal acc;
+    TestToken internal t1;
+    TestToken internal t2;
+    address internal payer = address(0xBEEF);
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        fee = new CoreFeeManager();
+        fee.initialize(address(acc));
+        t1 = new TestToken("T1", "T1");
+        t2 = new TestToken("T2", "T2");
+        t1.transfer(payer, 100 ether);
+        t2.transfer(payer, 100 ether);
+    }
+
+    function testCollectFee() public {
+        fee.setPercentFee(bytes32("M1"), address(t1), 500); // 5%
+        fee.setFixedFee(bytes32("M1"), address(t1), 1 ether);
+        vm.prank(payer);
+        t1.approve(address(fee), 100 ether);
+        uint256 f = fee.collect(bytes32("M1"), address(t1), payer, 20 ether);
+        assertEq(f, 2 ether); // 1 ether fixed + 5% of 20 = 2
+        assertEq(t1.balanceOf(address(fee)), 2 ether);
+    }
+
+    function testUnauthorizedSetFee() public {
+        address other = address(0xBAD);
+        vm.prank(other);
+        vm.expectRevert(abi.encodeWithSelector(NotFeatureOwner.selector));
+        fee.setPercentFee(bytes32("M1"), address(t2), 100);
+    }
+}
+

--- a/test/foundry/GasSubsidyManager.t.sol
+++ b/test/foundry/GasSubsidyManager.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {GasSubsidyManager} from "contracts/core/GasSubsidyManager.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+
+import {NotAdmin} from "contracts/errors/Errors.sol";
+contract GasSubsidyManagerTest is Test {
+    GasSubsidyManager internal gsm;
+    AccessControlCenter internal acc;
+    address internal user = address(0x1);
+    address internal other = address(0x2);
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        acc.grantRole(acc.AUTOMATION_ROLE(), address(this));
+        gsm = new GasSubsidyManager();
+        gsm.initialize(address(acc));
+    }
+
+    function testSetAndQueryEligibility() public {
+        bytes32 moduleId = bytes32("M1");
+        gsm.setGasRefundLimit(moduleId, 1 ether);
+        gsm.setEligibility(moduleId, user, true);
+        gsm.setGasCoverageEnabled(moduleId, address(this), true);
+        assertTrue(gsm.isGasFree(moduleId, user, address(this)));
+    }
+
+    function testUnauthorizedLimit() public {
+        bytes32 moduleId = bytes32("M1");
+        vm.prank(other);
+        vm.expectRevert(abi.encodeWithSelector(NotAdmin.selector));
+        gsm.setGasRefundLimit(moduleId, 1 ether);
+    }
+}
+

--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {Marketplace} from "contracts/modules/marketplace/Marketplace.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract MarketplaceTest is Test {
+    Marketplace internal market;
+    MockRegistry internal registry;
+    MockAccessControlCenter internal acc;
+    MockPaymentGateway internal gateway;
+    TestToken internal token;
+
+    address internal seller = address(0x1);
+    address internal buyer = address(0x2);
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        registry = new MockRegistry();
+        acc = new MockAccessControlCenter();
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        gateway = new MockPaymentGateway();
+        bytes32 moduleId = keccak256("Market");
+        market = new Marketplace(address(registry), address(gateway), moduleId);
+        token.transfer(buyer, 100 ether);
+    }
+
+    function testListAndBuy() public {
+        uint256 price = 1 ether;
+        vm.prank(seller);
+        vm.expectEmit(true, true, false, true);
+        emit Marketplace.MarketplaceListingCreated(0, seller, address(token), price);
+        uint256 id = market.list(address(token), price);
+        (address sellerAddr, address tkn, uint256 pr, bool active) = market.listings(id);
+        assertEq(sellerAddr, seller);
+        assertEq(tkn, address(token));
+        assertEq(pr, price);
+        assertTrue(active);
+
+        vm.prank(buyer);
+        token.approve(address(gateway), price);
+        vm.prank(buyer);
+        vm.expectEmit(true, true, false, true);
+        emit Marketplace.MarketplaceListingSold(id, buyer);
+        market.buy(id);
+
+        assertEq(token.balanceOf(seller), price);
+        assertEq(token.balanceOf(buyer), 99 ether);
+        (, , , active) = market.listings(id);
+        assertFalse(active);
+    }
+}
+

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {SubscriptionManager} from "contracts/modules/subscriptions/SubscriptionManager.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenterAuto} from "contracts/mocks/MockAccessControlCenterAuto.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract SubscriptionManagerTest is Test {
+    SubscriptionManager internal sub;
+    MockRegistry internal registry;
+    MockAccessControlCenterAuto internal acc;
+    MockPaymentGateway internal gateway;
+    TestToken internal token;
+
+    address internal merchant;
+    uint256 internal merchantPk = 1;
+    address internal user = address(0xBEEF);
+    address internal keeper = address(0xCAFE);
+
+    function setUp() public {
+        merchant = vm.addr(merchantPk);
+        token = new TestToken("T", "T");
+        registry = new MockRegistry();
+        acc = new MockAccessControlCenterAuto();
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        gateway = new MockPaymentGateway();
+        bytes32 moduleId = keccak256("Sub");
+        sub = new SubscriptionManager(address(registry), address(gateway), moduleId);
+        token.transfer(user, 10 ether);
+    }
+
+    function _defaultPlan() internal view returns (SignatureLib.Plan memory plan) {
+        plan = SignatureLib.Plan({
+            chainIds: new uint256[](1),
+            price: 1 ether,
+            period: 1 days,
+            token: address(token),
+            merchant: merchant,
+            salt: 1,
+            expiry: 0
+        });
+        plan.chainIds[0] = block.chainid;
+    }
+
+    function _sign(bytes32 digest) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testSubscribeAndRenew() public {
+        SignatureLib.Plan memory plan = _defaultPlan();
+        bytes32 planHash = sub.hashPlan(plan);
+        bytes memory sig = _sign(planHash);
+        vm.prank(user);
+        token.approve(address(gateway), plan.price * 2);
+        vm.prank(user);
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionManager.Subscribed(user, planHash, plan.price, address(token));
+        bytes memory empty;
+        sub.subscribe(plan, sig, empty);
+
+        (uint256 nextBilling, bytes32 storedHash) = sub.subscribers(user);
+        assertEq(storedHash, planHash);
+        uint256 expected = nextBilling;
+
+        vm.warp(expected + 1);
+        vm.prank(keeper);
+        sub.charge(user);
+        assertEq(token.balanceOf(merchant), 2 ether);
+        (nextBilling, ) = sub.subscribers(user);
+        assertEq(nextBilling, expected + plan.period);
+    }
+
+    function testUnsubscribe() public {
+        SignatureLib.Plan memory plan = _defaultPlan();
+        bytes32 planHash = sub.hashPlan(plan);
+        bytes memory sig = _sign(planHash);
+        vm.prank(user);
+        token.approve(address(gateway), plan.price);
+        vm.prank(user);
+        bytes memory empty;
+        sub.subscribe(plan, sig, empty);
+
+        vm.prank(user);
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionManager.Unsubscribed(user, planHash);
+        sub.unsubscribe();
+
+        bytes32 storedHash;
+        (, storedHash) = sub.subscribers(user);
+        assertEq(storedHash, bytes32(0));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add marketplace listing test
- cover subscription manager flow with renewals and unsubscribe
- add core fee manager fee calculation tests
- add gas subsidy manager tests for eligibility and access

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685dcb2a5ef88323a1a73e6e6f2d0912