### PR TITLE
Add core component tests

### DIFF
--- a/contracts/shared/NFTManager.sol
+++ b/contracts/shared/NFTManager.sol
@@ -31,7 +31,7 @@ contract NFTManager is ERC721URIStorage, Ownable {
 
     /// @notice Soulbound tokens are non-transferable
     function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
-        address from = ERC721.ownerOf(tokenId);
+        address from = _ownerOf(tokenId);
         if (!(from == address(0) || to == address(0) || !isSoulbound[tokenId])) revert SbtNonTransferable();
         return super._update(to, tokenId, auth);
     }

--- a/test/foundry/EventRouter.t.sol
+++ b/test/foundry/EventRouter.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {EventRouter} from "contracts/core/EventRouter.sol";
+import {InvalidKind} from "contracts/errors/Errors.sol";
+
+contract EventRouterTest is Test {
+    AccessControlCenter internal acc;
+    EventRouter internal router;
+    address internal module = address(0xBEEF);
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.MODULE_ROLE(), module);
+
+        router = new EventRouter();
+        router.initialize(address(acc));
+    }
+
+    function testRouteEmitsEvent() public {
+        bytes memory data = abi.encode(address(this), uint256(1));
+        vm.prank(module);
+        vm.expectEmit(true, false, false, true);
+        emit EventRouter.EventRouted(EventRouter.EventKind.ListingCreated, data);
+        router.route(EventRouter.EventKind.ListingCreated, data);
+    }
+
+    function testRouteInvalidKind() public {
+        vm.prank(module);
+        vm.expectRevert(abi.encodeWithSelector(InvalidKind.selector));
+        router.route(EventRouter.EventKind.Unknown, "");
+    }
+}

--- a/test/foundry/NFTManager.t.sol
+++ b/test/foundry/NFTManager.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {NFTManager} from "contracts/shared/NFTManager.sol";
+
+contract NFTManagerTest is Test {
+    NFTManager internal nft;
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    address internal user = address(0xABCD);
+    address internal other = address(0xDCBA);
+
+    function setUp() public {
+        nft = new NFTManager("Demo", "D");
+    }
+
+    function testMintAndBurn() public {
+        vm.expectEmit(true, true, true, true);
+        emit NFTManager.Minted(user, 1, "uri", false);
+        uint256 id = nft.mint(user, "uri", false);
+        assertEq(id, 1);
+        assertEq(nft.balanceOf(user), 1);
+
+        vm.expectEmit(true, true, true, false);
+        emit Transfer(user, address(0), id);
+        nft.burn(id);
+        assertEq(nft.balanceOf(user), 0);
+    }
+
+    function testTransferWithoutApproval() public {
+        uint256 id = nft.mint(user, "u", false);
+        vm.prank(other);
+        vm.expectRevert(abi.encodeWithSignature("ERC721InsufficientApproval(address,uint256)", other, id));
+        nft.transferFrom(user, other, id);
+    }
+}

--- a/test/foundry/Registry.t.sol
+++ b/test/foundry/Registry.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {Registry} from "contracts/core/Registry.sol";
+import {TokenRegistry} from "contracts/core/TokenRegistry.sol";
+import {InvalidImplementation, InvalidAddress, NotFound} from "contracts/errors/Errors.sol";
+
+contract RegistryTest is Test {
+    AccessControlCenter internal acc;
+    Registry internal registry;
+    TokenRegistry internal tokenReg;
+    bytes32 internal constant FEATURE_ID = keccak256("Feature1");
+    bytes32 internal constant MODULE_ID = keccak256("Module1");
+    address internal featureImpl = address(0x1234);
+    address internal newImpl = address(0x5678);
+    address internal token = address(0xCAFE);
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+
+        registry = new Registry();
+        registry.initialize(address(acc));
+
+        tokenReg = new TokenRegistry();
+        tokenReg.initialize(address(acc));
+    }
+
+    function testRegisterAndUpgradeFeature() public {
+        vm.expectEmit(true, true, false, true);
+        emit Registry.FeatureRegistered(FEATURE_ID, featureImpl, 1);
+        registry.registerFeature(FEATURE_ID, featureImpl, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Registry.FeatureUpdated(FEATURE_ID, featureImpl, newImpl);
+        registry.upgradeFeature(FEATURE_ID, newImpl);
+
+        (address impl, uint8 ctx) = registry.getFeature(FEATURE_ID);
+        assertEq(impl, newImpl);
+        assertEq(ctx, 1);
+    }
+
+    function testTokenWhitelist() public {
+        vm.expectEmit(true, true, false, true);
+        emit TokenRegistry.TokenWhitelisted(MODULE_ID, token, true);
+        tokenReg.setTokenAllowed(MODULE_ID, token, true);
+        assertTrue(tokenReg.isTokenAllowed(MODULE_ID, token));
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        vm.expectEmit(true, true, false, true);
+        emit TokenRegistry.TokenWhitelisted(MODULE_ID, token, false);
+        tokenReg.bulkSetTokenAllowed(MODULE_ID, tokens, false);
+        assertFalse(tokenReg.isTokenAllowed(MODULE_ID, token));
+    }
+
+    function testUpgradeFeatureInvalidAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidAddress.selector));
+        registry.upgradeFeature(FEATURE_ID, address(0));
+    }
+
+    function testGetFeatureNotFound() public {
+        vm.expectRevert(abi.encodeWithSelector(NotFound.selector));
+        registry.getFeature(FEATURE_ID);
+    }
+}


### PR DESCRIPTION
## Summary
- add EventRouter tests for routing and invalid kinds
- add Registry and TokenRegistry tests for feature and token management
- cover NFT minting, burning and transfer logic
- fix NFTManager mint bug using _ownerOf

## Testing
- `forge test -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd104f3688323b06bf0a15015ce68