### PR TITLE
Add initial Hardhat tests & CI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,31 @@ jobs:
       - name: Run Foundry tests
         run: forge test -vv
 
-      # 7) Run Hardhat JS tests (e2e/integration)
-      - name: Run Hardhat tests
-        run: npm test
+      # 7) Compile contracts with Hardhat
+      - name: Hardhat compile
+        run: npx hardhat compile
 
-      # 8) Forge coverage report + coverage gate (≥90%)
+      # 8) Run Hardhat JS tests (e2e/integration)
+      - name: Run Hardhat tests
+        run: npx hardhat test
+
+      # 9) Run showcase scripts
+      - name: Run showcase scripts
+        run: |
+          for f in scripts/showcase*.ts; do
+            npx hardhat run "$f" || exit 1
+          done
+
+      # 10) Forge coverage report + coverage gate (≥90%)
       - name: Forge coverage
         run: |
           forge coverage --report lcov
           bash scripts/check-coverage.sh 90
 
-      # 9) Hardhat coverage (using solidity-coverage)
+      # 11) Hardhat coverage (using solidity-coverage)
       - name: Hardhat coverage
         run: npm run coverage
 
-      # 10) Static analysis with Slither
+      # 12) Static analysis with Slither
       - name: Slither static
         run: slither . --fail-on-issue High

--- a/contracts/mocks/TestCloneFactory.sol
+++ b/contracts/mocks/TestCloneFactory.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../shared/CloneFactory.sol";
+
+contract DummyTemplate {
+    uint256 public value;
+    error InitFailed();
+
+    function init(uint256 v) external {
+        if (v == 0) revert InitFailed();
+        value = v;
+    }
+}
+
+contract TestCloneFactory is CloneFactory {
+    event Cloned(address indexed implementation, address indexed instance);
+
+    function clone(address impl, bytes32 salt, bytes memory initData) external returns (address) {
+        address inst = _clone(impl, salt, initData);
+        emit Cloned(impl, inst);
+        return inst;
+    }
+
+    function predict(address impl, bytes32 salt) external view returns (address) {
+        return _predict(impl, salt);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "clean": "npx hardhat clean",
     "compile": "npx hardhat compile",
-    "test": "node test/test-runner.js",
+    "test": "npx hardhat test",
     "coverage": "npx hardhat coverage",
     "node": "npx hardhat node",
     "deploy:local": "npx hardhat ignition deploy ignition/modules/LocalDeploy.ts --network localhost",

--- a/test/hardhat/cloneFactory.test.ts
+++ b/test/hardhat/cloneFactory.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("CloneFactory", function () {
+  let factory: any;
+  let template: any;
+
+  beforeEach(async () => {
+    const Factory = await ethers.getContractFactory("TestCloneFactory");
+    factory = await Factory.deploy();
+
+    const Template = await ethers.getContractFactory("DummyTemplate");
+    template = await Template.deploy();
+  });
+
+  it("clones template and initializes", async () => {
+    const salt = ethers.keccak256(ethers.toUtf8Bytes("one"));
+    const initData = new ethers.Interface(["function init(uint256)"]).encodeFunctionData("init", [42]);
+    const predicted = await factory.predict(await template.getAddress(), salt);
+    await expect(factory.clone(await template.getAddress(), salt, initData))
+      .to.emit(factory, "Cloned")
+      .withArgs(await template.getAddress(), predicted);
+    const cloneAddr = await factory.predict(await template.getAddress(), salt);
+    const clone = await ethers.getContractAt("DummyTemplate", cloneAddr);
+    expect(await clone.value()).to.equal(42n);
+    const code = await ethers.provider.getCode(cloneAddr);
+    expect(code.length / 2 - 1).to.equal(45); // hex string length minus 0x
+  });
+
+  it("reverts on init failure", async () => {
+    const salt = ethers.keccak256(ethers.toUtf8Bytes("two"));
+    const initData = new ethers.Interface(["function init(uint256)"]).encodeFunctionData("init", [0]);
+    await expect(factory.clone(await template.getAddress(), salt, initData))
+      .to.be.revertedWithCustomError(template, "InitFailed");
+  });
+
+  it("different salts produce different addresses", async () => {
+    const salt1 = ethers.hexZeroPad("0x01", 32);
+    const salt2 = ethers.hexZeroPad("0x02", 32);
+    const initData = new ethers.Interface(["function init(uint256)"]).encodeFunctionData("init", [1]);
+    const c1 = await factory.clone(await template.getAddress(), salt1, initData);
+    const c2 = await factory.clone(await template.getAddress(), salt2, initData);
+    expect(c1).to.not.equal(c2);
+  });
+});

--- a/test/hardhat/contestEscrow.test.ts
+++ b/test/hardhat/contestEscrow.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("ContestEscrow", function () {
+  let token: any;
+  let escrow: any;
+  let creator: any, w1: any, w2: any;
+
+  beforeEach(async () => {
+    [creator, w1, w2] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("TestToken");
+    token = await Token.deploy("T", "T");
+
+    const Registry = await ethers.getContractFactory("MockRegistry");
+    const registry = await Registry.deploy();
+
+    const prizes = [
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("100"), distribution: 0, uri: "" },
+      { prizeType: 0, token: await token.getAddress(), amount: ethers.parseEther("50"), distribution: 0, uri: "" },
+    ];
+
+    const Escrow = await ethers.getContractFactory("ContestEscrow");
+    const deadline = (await ethers.provider.getBlock("latest")).timestamp + 86400;
+    escrow = await Escrow.deploy(creator.address, prizes, await registry.getAddress(), 0, await token.getAddress(), deadline);
+    await token.transfer(await escrow.getAddress(), ethers.parseEther("150"));
+  });
+
+  it("finalize distributes prizes", async () => {
+    await escrow.connect(creator).finalize([w1.address, w2.address], 0, 0);
+    expect(await token.balanceOf(w1.address)).to.equal(ethers.parseEther("100"));
+    expect(await token.balanceOf(w2.address)).to.equal(ethers.parseEther("50"));
+    expect(await escrow.finalized()).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Hardhat tests for CloneFactory and ContestEscrow
- ship helper contracts for tests
- run `npx hardhat compile`, `npx hardhat test` and showcase scripts in CI
- update npm test script

## Testing
- `npx hardhat test` *(fails: Trying to use a non-local installation of Hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3d824bc8323b7bc12c1d92fe17c