### PR TITLE
Add tests for MultiValidator and PaymentGateway

### DIFF
--- a/contracts/mocks/MockValidator.sol
+++ b/contracts/mocks/MockValidator.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.8.28;
+
+contract MockValidator {
+    mapping(address => bool) public allowed;
+
+    function setToken(address token, bool status) external {
+        allowed[token] = status;
+    }
+
+    function isAllowed(address token) external view returns (bool) {
+        return allowed[token];
+    }
+}

--- a/test/foundry/MultiValidator.t.sol
+++ b/test/foundry/MultiValidator.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {MultiValidator} from "contracts/core/MultiValidator.sol";
+import {ZeroAddress, NotGovernor, NotAdmin} from "contracts/errors/Errors.sol";
+
+contract MultiValidatorTest is Test {
+    AccessControlCenter internal acc;
+    MultiValidator internal val;
+    address internal admin = address(0xA11CE);
+    address internal other = address(0xBEEF);
+
+    function setUp() public {
+        acc = new AccessControlCenter();
+        vm.prank(admin);
+        acc.initialize(admin);
+        val = new MultiValidator();
+        bytes32 role = acc.DEFAULT_ADMIN_ROLE();
+        vm.startPrank(admin);
+        acc.grantRole(role, address(val));
+        val.initialize(address(acc));
+        vm.stopPrank();
+    }
+
+    function testAddRemoveToken() public {
+        address token = address(0x1);
+        vm.prank(admin);
+        val.addToken(token);
+        assertTrue(val.isAllowed(token));
+        vm.prank(admin);
+        val.removeToken(token);
+        assertFalse(val.isAllowed(token));
+    }
+
+    function testBulkSetToken() public {
+        address t1 = address(0x1);
+        address t2 = address(0x2);
+        address[] memory arr = new address[](2);
+        arr[0] = t1;
+        arr[1] = t2;
+        vm.prank(admin);
+        val.bulkSetToken(arr, true);
+        assertTrue(val.isAllowed(t1));
+        assertTrue(val.isAllowed(t2));
+    }
+
+    function testSetTokenZeroReverts() public {
+        vm.prank(admin);
+        vm.expectRevert(ZeroAddress.selector);
+        val.addToken(address(0));
+    }
+
+    function testUnauthorizedSetToken() public {
+        vm.prank(other);
+        vm.expectRevert(NotGovernor.selector);
+        val.addToken(address(0x1));
+    }
+
+    function testSetAccessControlOnlyAdmin() public {
+        AccessControlCenter newAcc = new AccessControlCenter();
+        newAcc.initialize(address(0xCAFE));
+        vm.prank(other);
+        vm.expectRevert(NotAdmin.selector);
+        val.setAccessControl(address(newAcc));
+        vm.prank(admin);
+        val.setAccessControl(address(newAcc));
+        assertEq(address(val.access()), address(newAcc));
+    }
+}

--- a/test/foundry/PaymentGateway.t.sol
+++ b/test/foundry/PaymentGateway.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
+import {PaymentGateway} from "contracts/core/PaymentGateway.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockValidator} from "contracts/mocks/MockValidator.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+import {NotAllowedToken, NotFeatureOwner} from "contracts/errors/Errors.sol";
+
+contract PaymentGatewayTest is Test {
+    AccessControlCenter internal acc;
+    CoreFeeManager internal fee;
+    PaymentGateway internal gate;
+    MockRegistry internal reg;
+    MockValidator internal val;
+    TestToken internal token;
+
+    address internal payer = address(0xBEEF);
+    uint256 internal payerKey = 0xBEEF;
+    address internal relayer = address(0xCAFE);
+
+    bytes32 internal moduleId = keccak256("Mod");
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), payer);
+
+        fee = new CoreFeeManager();
+        fee.initialize(address(acc));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
+        fee.setPercentFee(moduleId, address(token), 500); // 5%
+
+        reg = new MockRegistry();
+        val = new MockValidator();
+        val.setToken(address(token), true);
+        reg.setModuleServiceAlias(moduleId, "Validator", address(val));
+
+        gate = new PaymentGateway();
+        gate.initialize(address(acc), address(reg), address(fee));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(gate));
+
+        token.transfer(payer, 10 ether);
+    }
+
+    function testProcessPayment() public {
+        uint256 amount = 1 ether;
+        vm.prank(payer);
+        token.approve(address(gate), amount);
+        vm.prank(payer);
+        uint256 net = gate.processPayment(moduleId, address(token), payer, amount, "");
+        assertEq(net, 0.95 ether);
+        assertEq(token.balanceOf(payer), 9.95 ether);
+        assertEq(token.balanceOf(address(fee)), 0.05 ether);
+        assertEq(token.balanceOf(address(gate)), 0);
+    }
+
+    function testUnauthorizedCaller() public {
+        vm.prank(relayer);
+        vm.expectRevert(NotFeatureOwner.selector);
+        gate.processPayment(moduleId, address(token), relayer, 1 ether, "");
+    }
+
+    function testNotAllowedToken() public {
+        val.setToken(address(token), false);
+        vm.prank(payer);
+        token.approve(address(gate), 1 ether);
+        vm.prank(payer);
+        vm.expectRevert(NotAllowedToken.selector);
+        gate.processPayment(moduleId, address(token), payer, 1 ether, "");
+    }
+}


### PR DESCRIPTION
## Summary
- add `MockValidator` helper contract
- create Foundry tests for `MultiValidator`
- create Foundry tests for `PaymentGateway`
- drop vendored submodules

## Testing
- `forge test -vv`
- `npm test` *(fails: hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ed64963f08323bbe010119ca090ba