### PR TITLE
Fix validator role issue in showcase script

### DIFF
--- a/scripts/showcase.ts
+++ b/scripts/showcase.ts
@@ -4,7 +4,7 @@ async function deployCore() {
   const Token = await ethers.getContractFactory("TestToken");
   const token = await Token.deploy("USD Coin", "USDC");
 
-  const ACL = await ethers.getContractFactory("MockAccessControlCenter");
+  const ACL = await ethers.getContractFactory("MockAccessControlCenterAuto");
   const acl = await ACL.deploy();
 
   const Registry = await ethers.getContractFactory("MockRegistry");


### PR DESCRIPTION
## Summary
- use `MockAccessControlCenterAuto` in the showcase script so the governor role check passes

## Testing
- `npx hardhat test` *(fails: Needs to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685f019362b48323b106758e23cd502e