### PR TITLE
Add Hardhat Ignition modules

### DIFF
--- a/ignition/modules/CoreModule.ts
+++ b/ignition/modules/CoreModule.ts
@@ -1,0 +1,30 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+import { ethers } from "ethers";
+
+const CoreModule = buildModule("CoreModule", (m) => {
+  m.getParameter("treasuryAddress", ethers.ZeroAddress);
+  m.getParameter("platformFeePercentage", 0);
+  m.getParameter("minContestDuration", 0);
+  m.getParameter("maxContestDuration", 0);
+
+  const deployer = m.getAccount(0);
+
+  const access = m.contract("AccessControlCenter");
+  m.call(access, "initialize", [deployer]);
+
+  const registry = m.contract("Registry");
+  m.call(registry, "initialize", [access]);
+
+  const feeManager = m.contract("CoreFeeManager");
+  m.call(feeManager, "initialize", [access]);
+
+  const gateway = m.contract("PaymentGateway");
+  m.call(gateway, "initialize", [access, registry, feeManager]);
+
+  const tokenValidator = m.contract("MultiValidator");
+  m.call(tokenValidator, "initialize", [access]);
+
+  return { access, registry, feeManager, gateway, tokenValidator };
+});
+
+export default CoreModule;

--- a/ignition/modules/LocalDeploy.ts
+++ b/ignition/modules/LocalDeploy.ts
@@ -1,0 +1,25 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+import { ethers } from "ethers";
+import CoreModule from "./CoreModule";
+
+const LocalDeploy = buildModule("LocalDeploy", (m) => {
+  const { access, registry, feeManager, gateway, tokenValidator } = m.useModule(CoreModule);
+
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  const deployer = m.getAccount(0);
+  m.call(access, "grantRole", [FACTORY_ADMIN, deployer]);
+  m.call(access, "grantRole", [m.staticCall(access, "FEATURE_OWNER_ROLE"), deployer]);
+  m.call(access, "grantRole", [m.staticCall(access, "GOVERNOR_ROLE"), deployer]);
+
+  const token = m.contract("TestToken", ["Demo", "DEMO"]);
+
+  const contestValidator = m.contract("ContestValidator", [access, tokenValidator]);
+  const contestFactory = m.contract("ContestFactory", [registry, feeManager]);
+  const CONTEST_ID = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+  m.call(registry, "registerFeature", [CONTEST_ID, contestFactory, 0]);
+  m.call(registry, "setModuleServiceAlias", [CONTEST_ID, "Validator", contestValidator]);
+
+  return { access, registry, feeManager, gateway, token, contestFactory };
+});
+
+export default LocalDeploy;

--- a/ignition/modules/PublicDeploy.ts
+++ b/ignition/modules/PublicDeploy.ts
@@ -1,0 +1,37 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+import { ethers } from "ethers";
+import CoreModule from "./CoreModule";
+
+const PublicDeploy = buildModule("PublicDeploy", (m) => {
+  const { access, registry, feeManager, gateway, tokenValidator } = m.useModule(CoreModule);
+
+  const treasury = m.getParameter("treasuryAddress");
+  const weth = m.getParameter("wethAddress");
+  const usdc = m.getParameter("usdcAddress");
+  const usdt = m.getParameter("usdtAddress");
+  const wethFeed = m.getParameter("wethPriceFeed");
+  const usdcFeed = m.getParameter("usdcPriceFeed");
+  const usdtFeed = m.getParameter("usdtPriceFeed");
+  const multisig = m.getParameter("multisigAddress");
+
+  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
+  const deployer = m.getAccount(0);
+  m.call(access, "grantRole", [FACTORY_ADMIN, deployer]);
+  m.call(access, "grantRole", [m.staticCall(access, "FEATURE_OWNER_ROLE"), deployer]);
+  m.call(access, "grantRole", [m.staticCall(access, "GOVERNOR_ROLE"), deployer]);
+  m.call(access, "grantRole", [m.staticCall(access, "GOVERNOR_ROLE"), multisig]);
+
+  const contestValidator = m.contract("ContestValidator", [access, tokenValidator]);
+  const contestFactory = m.contract("ContestFactory", [registry, feeManager]);
+  const CONTEST_ID = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
+  m.call(registry, "registerFeature", [CONTEST_ID, contestFactory, 0]);
+  m.call(registry, "setModuleServiceAlias", [CONTEST_ID, "Validator", contestValidator]);
+
+  m.call(tokenValidator, "addToken", [weth]);
+  m.call(tokenValidator, "addToken", [usdc]);
+  m.call(tokenValidator, "addToken", [usdt]);
+
+  return { access, registry, feeManager, gateway, contestFactory };
+});
+
+export default PublicDeploy;


### PR DESCRIPTION
## Summary
- add Ignition modules for Hardhat deployments
  - `CoreModule` deploys the core contracts
  - `LocalDeploy` sets up a local environment with a test token
  - `PublicDeploy` prepares a public deployment with token allow list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f092651c08323ba963cd9cca3e824