### PR TITLE
Fix demos and ignition modules

### DIFF
--- a/ignition/modules/CoreModule.ts
+++ b/ignition/modules/CoreModule.ts
@@ -1,56 +1,39 @@
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 import { ethers } from "ethers";
 
-const CoreModule = buildModule("CoreModule", (m) => {
-  m.getParameter("treasuryAddress", ethers.ZeroAddress);
-  m.getParameter("platformFeePercentage", 0);
-  m.getParameter("minContestDuration", 0);
-  m.getParameter("maxContestDuration", 0);
-
-  const deployer = m.getAccount(0);
-
-  const access = m.contract("AccessControlCenter");
-  m.call(access, "initialize", [deployer]);
-
-  const registry = m.contract("Registry");
-  m.call(registry, "initialize", [access]);
-import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
-import { ethers } from "ethers";
-
 /**
  * Модуль развертывания основных контрактов системы
  */
-const CoreModule = buildModule("CoreModule", async (m) => {
-  // Константы модулей и сервисов
-  const ACCESS_SERVICE = ethers.keccak256(ethers.toUtf8Bytes("AccessControlCenter"));
-  const PAYMENT_GATEWAY_SERVICE = ethers.keccak256(ethers.toUtf8Bytes("PaymentGateway"));
-  const VALIDATOR_SERVICE = ethers.keccak256(ethers.toUtf8Bytes("SERVICE_VALIDATOR"));
+const CoreModule = buildModule("CoreModule", (m) => {
+  const ACCESS_SERVICE = ethers.keccak256(
+    ethers.toUtf8Bytes("AccessControlCenter")
+  );
+  const PAYMENT_GATEWAY_SERVICE = ethers.keccak256(
+    ethers.toUtf8Bytes("PaymentGateway")
+  );
+  const VALIDATOR_SERVICE = ethers.keccak256(
+    ethers.toUtf8Bytes("SERVICE_VALIDATOR")
+  );
   const MARKETPLACE_ID = ethers.keccak256(ethers.toUtf8Bytes("Marketplace"));
 
-  // Развертывание базовых контрактов
   const access = m.contract("AccessControlCenter", []);
   const registry = m.contract("Registry", [access]);
   const feeManager = m.contract("CoreFeeManager", []);
   m.call(feeManager, "initialize", [access]);
 
-  // Регистрация базовых сервисов в реестре
   m.call(registry, "setCoreService", [ACCESS_SERVICE, access]);
   m.call(registry, "setCoreService", [PAYMENT_GATEWAY_SERVICE, feeManager]);
 
-  // Развертывание и инициализация платежного шлюза
   const gateway = m.contract("PaymentGateway", []);
   m.call(gateway, "initialize", [access, registry, feeManager]);
 
-  // Развертывание валидатора токенов
   const tokenValidator = m.contract("MultiValidator", []);
   m.call(tokenValidator, "initialize", [access]);
 
-  // Регистрация маркетплейса
   const marketplaceFactory = m.contract("MarketplaceFactory", [registry, gateway]);
   m.call(registry, "registerFeature", [MARKETPLACE_ID, marketplaceFactory, 0]);
   m.call(registry, "setModuleService", [MARKETPLACE_ID, VALIDATOR_SERVICE, tokenValidator]);
 
-  // Настройка прайс-фида для тестовой сети (опционально)
   const priceFeed = m.contract("MockPriceFeed", []);
 
   return {
@@ -60,21 +43,8 @@ const CoreModule = buildModule("CoreModule", async (m) => {
     gateway,
     tokenValidator,
     marketplaceFactory,
-    priceFeed
+    priceFeed,
   };
-});
-
-export default CoreModule;
-  const feeManager = m.contract("CoreFeeManager");
-  m.call(feeManager, "initialize", [access]);
-
-  const gateway = m.contract("PaymentGateway");
-  m.call(gateway, "initialize", [access, registry, feeManager]);
-
-  const tokenValidator = m.contract("MultiValidator");
-  m.call(tokenValidator, "initialize", [access]);
-
-  return { access, registry, feeManager, gateway, tokenValidator };
 });
 
 export default CoreModule;

--- a/ignition/modules/PublicDeploy.ts
+++ b/ignition/modules/PublicDeploy.ts
@@ -2,78 +2,35 @@ import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 import { ethers } from "ethers";
 import CoreModule from "./CoreModule";
 
-const PublicDeploy = buildModule("PublicDeploy", (m) => {
-  const { access, registry, feeManager, gateway, tokenValidator } = m.useModule(CoreModule);
-
-  const treasury = m.getParameter("treasuryAddress");
-  const weth = m.getParameter("wethAddress");
-  const usdc = m.getParameter("usdcAddress");
-  const usdt = m.getParameter("usdtAddress");
-  const wethFeed = m.getParameter("wethPriceFeed");
-  const usdcFeed = m.getParameter("usdcPriceFeed");
-  const usdtFeed = m.getParameter("usdtPriceFeed");
-  const multisig = m.getParameter("multisigAddress");
-
-  const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
-  const deployer = m.getAccount(0);
-  m.call(access, "grantRole", [FACTORY_ADMIN, deployer]);
-  m.call(access, "grantRole", [m.staticCall(access, "FEATURE_OWNER_ROLE"), deployer]);
-  m.call(access, "grantRole", [m.staticCall(access, "GOVERNOR_ROLE"), deployer]);
-  m.call(access, "grantRole", [m.staticCall(access, "GOVERNOR_ROLE"), multisig]);
-
-  const contestValidator = m.contract("ContestValidator", [access, tokenValidator]);
-  const contestFactory = m.contract("ContestFactory", [registry, feeManager]);
-  const CONTEST_ID = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
-  m.call(registry, "registerFeature", [CONTEST_ID, contestFactory, 0]);
-  m.call(registry, "setModuleServiceAlias", [CONTEST_ID, "Validator", contestValidator]);
-
-  m.call(tokenValidator, "addToken", [weth]);
-  m.call(tokenValidator, "addToken", [usdc]);
-  m.call(tokenValidator, "addToken", [usdt]);
-import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
-import { ethers } from "ethers";
-import CoreModule from "./CoreModule";
-
 /**
  * Модуль для развертывания в публичной сети
  */
 const PublicDeploy = buildModule("PublicDeploy", (m) => {
-  // Импортируем базовые контракты из CoreModule
   const core = m.useModule(CoreModule);
 
-  // Получаем константы ролей
   const FACTORY_ADMIN = ethers.keccak256(ethers.toUtf8Bytes("FACTORY_ADMIN"));
   const FEATURE_OWNER_ROLE = m.staticCall(core.access, "FEATURE_OWNER_ROLE");
   const GOVERNOR_ROLE = m.staticCall(core.access, "GOVERNOR_ROLE");
   const DEFAULT_ADMIN_ROLE = m.staticCall(core.access, "DEFAULT_ADMIN_ROLE");
 
-  // Получаем адрес развертывателя
   const deployer = m.getAccount(0);
-
-  // Назначаем роли
   m.call(core.access, "grantRole", [DEFAULT_ADMIN_ROLE, deployer]);
   m.call(core.access, "grantRole", [FACTORY_ADMIN, deployer]);
   m.call(core.access, "grantRole", [FEATURE_OWNER_ROLE, deployer]);
   m.call(core.access, "grantRole", [GOVERNOR_ROLE, deployer]);
 
-  // Разворачиваем дополнительные модули для публичной сети
   const CONTEST_ID = ethers.keccak256(ethers.toUtf8Bytes("Contest"));
   const contestValidator = m.contract("ContestValidator", [core.access, core.tokenValidator]);
   const contestFactory = m.contract("ContestFactory", [core.registry, core.feeManager]);
 
-  // Регистрируем модуль конкурсов
   m.call(core.registry, "registerFeature", [CONTEST_ID, contestFactory, 0]);
   m.call(core.registry, "setModuleServiceAlias", [CONTEST_ID, "Validator", contestValidator]);
 
   return {
     ...core,
     contestFactory,
-    contestValidator
+    contestValidator,
   };
-});
-
-export default PublicDeploy;
-  return { access, registry, feeManager, gateway, contestFactory };
 });
 
 export default PublicDeploy;

--- a/scripts/showcase-marketplace.ts
+++ b/scripts/showcase-marketplace.ts
@@ -87,7 +87,8 @@ async function getModuleServiceByAlias(registry: Contract, moduleId: string, ser
           }
         }
       } catch (methodError) {
-        console.log(`Метод ${method.name} не сработал:`, methodError.message);
+        const err = methodError as Error;
+        console.log(`Метод ${method.name} не сработал:`, err.message);
         // Продолжаем со следующим методом
       }
     }

--- a/scripts/showcase.ts
+++ b/scripts/showcase.ts
@@ -7,7 +7,8 @@ async function deployCore() {
   // Создаем и инициализируем систему контроля доступа
   const ACL = await ethers.getContractFactory("AccessControlCenter");
   const acl = await ACL.deploy();
-  await acl.initialize(await ethers.provider.getSigner(0).getAddress()); // Инициализируем ACL с первым аккаунтом как админом
+  const [deployerSigner] = await ethers.getSigners();
+  await acl.initialize(deployerSigner.address); // Инициализируем ACL с первым аккаунтом как админом
 
   // Создаем реестр сервисов
   const Registry = await ethers.getContractFactory("Registry");

--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -108,7 +108,7 @@ async function massFinalize(count = 1000) {
 async function batchCharge(users = 10000, chunk = 100) {
   const [owner, merchant] = await ethers.getSigners();
   const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("Test", "TST");
+  const token = (await Token.deploy("Test", "TST")) as any;
 
   const ACL = await ethers.getContractFactory("MockAccessControlCenterAuto");
   const acl = await ACL.deploy();
@@ -125,11 +125,11 @@ async function batchCharge(users = 10000, chunk = 100) {
 
   const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Sub"));
   const Manager = await ethers.getContractFactory("SubscriptionManager");
-  const manager = await Manager.deploy(
+  const manager = (await Manager.deploy(
     await registry.getAddress(),
     await gateway.getAddress(),
     moduleId
-  );
+  )) as any;
 
   const plan = {
     chainIds: [31337n],
@@ -166,7 +166,7 @@ async function batchCharge(users = 10000, chunk = 100) {
 async function parallelBuys(buyers = 500) {
   const [seller] = await ethers.getSigners();
   const Token = await ethers.getContractFactory("TestToken");
-  const token = await Token.deploy("Sale", "SALE");
+  const token = (await Token.deploy("Sale", "SALE")) as any;
 
   const ACL = await ethers.getContractFactory("MockAccessControlCenterAuto");
   const acl = await ACL.deploy();
@@ -183,11 +183,11 @@ async function parallelBuys(buyers = 500) {
 
   const moduleId = ethers.keccak256(ethers.toUtf8Bytes("Market"));
   const Market = await ethers.getContractFactory("Marketplace");
-  const market = await Market.deploy(
+  const market = (await Market.deploy(
     await registry.getAddress(),
     await gateway.getAddress(),
     moduleId
-  );
+  )) as any;
 
   const listingTx = await market.list(await token.getAddress(), ethers.parseEther("1"));
   const rc = await listingTx.wait();

--- a/test/hardhat/contestEscrow.test.ts
+++ b/test/hardhat/contestEscrow.test.ts
@@ -21,7 +21,8 @@ describe("ContestEscrow", function () {
     ];
 
     const Escrow = await ethers.getContractFactory("ContestEscrow");
-    const deadline = (await ethers.provider.getBlock("latest")).timestamp + 86400;
+    const latestBlock = await ethers.provider.getBlock("latest");
+    const deadline = (latestBlock!).timestamp + 86400;
     escrow = await Escrow.connect(deployer).deploy(creator.address, prizes, await registry.getAddress(), 0, await token.getAddress(), deadline);
     await token.transfer(await escrow.getAddress(), ethers.parseEther("150"));
   });


### PR DESCRIPTION
## Summary
- clean up ignition modules and remove duplicates
- fix initialization in showcase script
- handle errors in showcase-marketplace
- cast contracts to allow method calls in stress demo
- ensure block retrieval in tests

## Testing
- `npx tsc --noEmit`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68608dcd68cc8323986368444287a5d2