### PR TITLE
Fix module constructors to avoid role errors

### DIFF
--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -51,7 +51,7 @@ contract Marketplace is AccessManaged {
     ) AccessManaged(Registry(_registry).getCoreService(keccak256('AccessControlCenter'))) {
         registry = Registry(_registry);
         MODULE_ID = moduleId;
-        registry.setModuleServiceAlias(MODULE_ID, 'PaymentGateway', paymentGateway);
+        // Service registration moved outside the constructor to avoid role issues
 
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
@@ -61,11 +61,7 @@ contract Marketplace is AccessManaged {
             )
         );
 
-        AccessControlCenter acl = AccessControlCenter(_ACC);
-        bytes32[] memory roles = new bytes32[](2);
-        roles[0] = acl.MODULE_ROLE();
-        roles[1] = acl.FEATURE_OWNER_ROLE();
-        _grantSelfRoles(roles);
+        // Role assignment should be handled externally after deployment
     }
 
     /// @notice Put an item for sale

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -75,7 +75,7 @@ contract SubscriptionManager is AccessManaged {
     ) AccessManaged(Registry(_registry).getCoreService(keccak256('AccessControlCenter'))) {
         registry = Registry(_registry);
         MODULE_ID = moduleId;
-        registry.setModuleServiceAlias(MODULE_ID, 'PaymentGateway', paymentGateway);
+        // Service registration handled externally after deployment
 
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
@@ -85,11 +85,7 @@ contract SubscriptionManager is AccessManaged {
             )
         );
 
-        AccessControlCenter acl = AccessControlCenter(_ACC);
-        bytes32[] memory roles = new bytes32[](2);
-        roles[0] = acl.MODULE_ROLE();
-        roles[1] = acl.FEATURE_OWNER_ROLE();
-        _grantSelfRoles(roles);
+        // Role assignment should be done outside the constructor
 
         batchLimit = 0;
     }


### PR DESCRIPTION
## Summary
- remove internal service registration and role self-granting from `Marketplace` and `SubscriptionManager` constructors

## Testing
- `npx hardhat compile`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_686102f3c6188323812027503c5c9d82