### PR TITLE
Fix compile warnings in Marketplace modules

### DIFF
--- a/contracts/modules/marketplace/Marketplace.sol
+++ b/contracts/modules/marketplace/Marketplace.sol
@@ -46,7 +46,7 @@ contract Marketplace is AccessManaged {
 
     constructor(
         address _registry,
-        address paymentGateway,
+        address /* paymentGateway */,
         bytes32 moduleId
     ) AccessManaged(Registry(_registry).getCoreService(keccak256('AccessControlCenter'))) {
         registry = Registry(_registry);

--- a/contracts/modules/marketplace/MarketplaceProxy.sol
+++ b/contracts/modules/marketplace/MarketplaceProxy.sol
@@ -23,6 +23,8 @@ contract MarketplaceProxy {
         implementation = _implementation;
     }
 
+    receive() external payable {}
+
     fallback() external payable {
         address impl = implementation;
         assembly {

--- a/contracts/modules/subscriptions/SubscriptionManager.sol
+++ b/contracts/modules/subscriptions/SubscriptionManager.sol
@@ -66,11 +66,10 @@ contract SubscriptionManager is AccessManaged {
 
     /// @notice Initializes the subscription manager and registers services
     /// @param _registry Address of the core Registry contract
-    /// @param paymentGateway Payment gateway used to process fees
     /// @param moduleId Unique module identifier
     constructor(
         address _registry,
-        address paymentGateway,
+        address /* paymentGateway */,
         bytes32 moduleId
     ) AccessManaged(Registry(_registry).getCoreService(keccak256('AccessControlCenter'))) {
         registry = Registry(_registry);


### PR DESCRIPTION
## Summary
- add missing `receive()` in MarketplaceProxy
- comment unused constructor parameters to silence warnings
- clean subscription manager docs

## Testing
- `npm test`
- `npx hardhat compile --force`

------
https://chatgpt.com/codex/tasks/task_e_68610c404c6c83239561f9f1bafb347f