### PR TITLE
Fix initialize admin logic

### DIFF
--- a/contracts/core/AccessControlCenter.sol
+++ b/contracts/core/AccessControlCenter.sol
@@ -17,9 +17,14 @@ contract AccessControlCenter is Initializable, AccessControlUpgradeable, UUPSUpg
     /// Role for managing token validators
     bytes32 public constant GOVERNOR_ROLE = keccak256('GOVERNOR_ROLE');
 
+    /// @notice Address holding the DEFAULT_ADMIN_ROLE
+    address public adminAddr;
+
     function initialize(address admin) public initializer {
+        if (admin == address(0)) revert InvalidAddress();
         __AccessControl_init();
         __UUPSUpgradeable_init();
+        adminAddr = admin;
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
@@ -49,5 +54,5 @@ contract AccessControlCenter is Initializable, AccessControlUpgradeable, UUPSUpg
         if (newImplementation == address(0)) revert InvalidImplementation();
     }
 
-    uint256[50] private __gap;
+    uint256[49] private __gap;
 }

--- a/contracts/mocks/MockRegistry.sol
+++ b/contracts/mocks/MockRegistry.sol
@@ -11,6 +11,10 @@ contract MockRegistry {
         moduleServices[moduleId][keccak256(bytes(serviceAlias))] = addr;
     }
 
+    function getModuleServiceByAlias(bytes32 moduleId, string calldata serviceAlias) external view returns (address) {
+        return moduleServices[moduleId][keccak256(bytes(serviceAlias))];
+    }
+
     function getModuleService(bytes32 moduleId, bytes32 serviceId) external view returns (address) {
         return moduleServices[moduleId][serviceId];
     }

--- a/test/foundry/AccessControlCenter.t.sol
+++ b/test/foundry/AccessControlCenter.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract AccessControlCenterTest is Test {
@@ -17,6 +18,7 @@ contract AccessControlCenterTest is Test {
         bytes memory data = abi.encodeCall(AccessControlCenter.initialize, admin);
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
         acc = AccessControlCenter(address(proxy));
+        assertEq(acc.adminAddr(), admin);
     }
 
     function testGrantAndRevokeRole() public {
@@ -51,6 +53,11 @@ contract AccessControlCenterTest is Test {
         vm.prank(admin);
         vm.expectRevert(UUPSUpgradeable.UUPSUnauthorizedCallContext.selector);
         impl.upgradeToAndCall(address(newImpl), bytes(""));
+    }
+
+    function testReinitializeReverts() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        acc.initialize(admin);
     }
 }
 

--- a/test/foundry/Marketplace.t.sol
+++ b/test/foundry/Marketplace.t.sol
@@ -25,6 +25,7 @@ contract MarketplaceTest is Test {
         registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
         gateway = new MockPaymentGateway();
         bytes32 moduleId = keccak256("Market");
+        registry.setModuleServiceAlias(moduleId, "PaymentGateway", address(gateway));
         market = new Marketplace(address(registry), address(gateway), moduleId);
         token.transfer(buyer, 100 ether);
     }

--- a/test/foundry/MultiValidator.t.sol
+++ b/test/foundry/MultiValidator.t.sol
@@ -14,12 +14,11 @@ contract MultiValidatorTest is Test {
 
     function setUp() public {
         acc = new AccessControlCenter();
-        vm.prank(admin);
-        acc.initialize(admin);
-        val = new MultiValidator();
-        bytes32 role = acc.DEFAULT_ADMIN_ROLE();
         vm.startPrank(admin);
-        acc.grantRole(role, address(val));
+        acc.initialize(admin);
+        acc.grantRole(acc.GOVERNOR_ROLE(), admin);
+        val = new MultiValidator();
+        acc.grantRole(acc.DEFAULT_ADMIN_ROLE(), address(val));
         val.initialize(address(acc));
         vm.stopPrank();
     }

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -29,6 +29,7 @@ contract SubscriptionManagerTest is Test {
         registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
         gateway = new MockPaymentGateway();
         bytes32 moduleId = keccak256("Sub");
+        registry.setModuleServiceAlias(moduleId, "PaymentGateway", address(gateway));
         sub = new SubscriptionManager(address(registry), address(gateway), moduleId);
         token.transfer(user, 10 ether);
     }


### PR DESCRIPTION
## Summary
- store adminAddr on initialization and check for zero address
- expose adminAddr in test setup
- add MockRegistry helper
- fix tests for subscriptions, marketplace and validator

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68611bfe10f48323a6e3e72e53644ada