### PR TITLE
Fix Forge coverage stack depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       # 10) Forge coverage report + coverage gate (≥90%)
       - name: Forge coverage
         run: |
-          forge coverage --report lcov
+          forge coverage --report lcov --ir-minimum
           bash scripts/check-coverage.sh 90
 
       # 11) Hardhat coverage (using solidity-coverage)

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -29,7 +29,7 @@ Tasks:
   integration  Run Hardhat JS tests
   e2e          Alias for integration
   all          Run both Forge and Hardhat tests
-  coverage     Run coverage for Forge and Hardhat
+  coverage     Run coverage for Forge and Hardhat (uses --ir-minimum for Forge)
   quick        Alias for unit
   --help       Show this help
 `);
@@ -52,7 +52,7 @@ function main() {
       code |= hardhat(['test']);
       break;
     case 'coverage':
-      code |= forge(['coverage', '--report', 'lcov']);
+      code |= forge(['coverage', '--report', 'lcov', '--ir-minimum']);
       code |= run('npm', ['run', 'coverage']);
       break;
     default:


### PR DESCRIPTION
## Summary
- ensure `forge coverage` runs with viaIR to avoid stack depth errors

## Testing
- `forge coverage --report lcov --ir-minimum`

------
https://chatgpt.com/codex/tasks/task_e_6861822267888323bf83a03b6812fd16