### PR TITLE
Fix Foundry test warnings

### DIFF
--- a/test/foundry/CloneFactory.t.sol
+++ b/test/foundry/CloneFactory.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 import "contracts/shared/CloneFactory.sol";
+import "contracts/errors/Errors.sol";
 
 contract DummyTemplate {
     uint256 public value;
-    error InitFailed();
 
     function init(uint256 v) external {
         if (v == 0) revert InitFailed();
@@ -53,7 +53,7 @@ contract CloneFactoryTest is Test {
     function testInitFailure() public {
         bytes32 salt = keccak256("two");
         bytes memory initData = abi.encodeCall(DummyTemplate.init, (0));
-        vm.expectRevert(DummyTemplate.InitFailed.selector);
+        vm.expectRevert(InitFailed.selector);
         factory.clone(address(template), salt, initData);
     }
 

--- a/test/foundry/SubscriptionManager.t.sol
+++ b/test/foundry/SubscriptionManager.t.sol
@@ -47,7 +47,7 @@ contract SubscriptionManagerTest is Test {
         plan.chainIds[0] = block.chainid;
     }
 
-    function _sign(bytes32 digest) internal returns (bytes memory) {
+    function _sign(bytes32 digest) internal view returns (bytes memory) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, digest);
         return abi.encodePacked(r, s, v);
     }


### PR DESCRIPTION
## Summary
- use global `InitFailed` error in `CloneFactory.t.sol`
- mark `_sign` as `view` in `SubscriptionManager.t.sol`

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_686186a246188323b5b230c3b95e7845