### PR TITLE
Exclude mocks from Forge coverage

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,4 @@ optimizer_runs = 200
 via_ir = true
 
 gas_reports = ['*']
+no_match_coverage = '.*/mocks/.*'


### PR DESCRIPTION
## Summary
- prevent Forge from counting mock contracts in coverage metrics

## Testing
- `npx hardhat compile`
- `node test/test-runner.js coverage`
- `bash scripts/check-coverage.sh 90`


------
https://chatgpt.com/codex/tasks/task_e_68619a39346883239191a0c5e36d5866