### PR TITLE
Fix coverage script path

### DIFF
--- a/.github/check-coverage.sh
+++ b/.github/check-coverage.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 set -e
 THRESHOLD=${1:-90}
-if [ ! -f coverage/lcov.info ]; then
-  echo "coverage/lcov.info not found"
+FILE=""
+if [ -f coverage/lcov.info ]; then
+  FILE="coverage/lcov.info"
+elif [ -f lcov.info ]; then
+  FILE="lcov.info"
+else
+  echo "lcov.info not found" >&2
   exit 1
 fi
-LF=$(grep -h "^LF:" coverage/lcov.info | awk -F':' '{sum+=$2} END {print sum}')
-LH=$(grep -h "^LH:" coverage/lcov.info | awk -F':' '{sum+=$2} END {print sum}')
+LF=$(grep -h "^LF:" "$FILE" | awk -F':' '{sum+=$2} END {print sum}')
+LH=$(grep -h "^LH:" "$FILE" | awk -F':' '{sum+=$2} END {print sum}')
 if [ -z "$LF" ] || [ -z "$LH" ] || [ "$LF" -eq 0 ]; then
   echo "Unable to calculate coverage"
   exit 1

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 THRESHOLD=${1:-90}
-FILE="coverage/lcov.info"
-if [ ! -f "$FILE" ]; then
-  echo "$FILE not found" >&2
+FILE=""
+if [ -f coverage/lcov.info ]; then
+  FILE="coverage/lcov.info"
+elif [ -f lcov.info ]; then
+  FILE="lcov.info"
+else
+  echo "lcov.info not found" >&2
   exit 1
 fi
 LF=$(grep -h "^LF:" "$FILE" | awk -F':' '{sum+=$2} END {print sum}')


### PR DESCRIPTION
## Summary
- allow coverage check to use `lcov.info` from either the repository root or `coverage` directory

## Testing
- `npm test`
- `npm run coverage`
- `bash scripts/check-coverage.sh 90`
- `bash .github/check-coverage.sh 90`


------
https://chatgpt.com/codex/tasks/task_e_6861a16f8f6483239a1f9e2ddf6bed74