### PR TITLE
Add foundry tests for factories

### DIFF
--- a/contracts/mocks/MockRegistry.sol
+++ b/contracts/mocks/MockRegistry.sol
@@ -19,6 +19,10 @@ contract MockRegistry {
         return moduleServices[moduleId][serviceId];
     }
 
+    function setModuleService(bytes32 moduleId, bytes32 serviceId, address addr) external {
+        moduleServices[moduleId][serviceId] = addr;
+    }
+
     function setCoreService(bytes32 serviceId, address addr) external {
         coreServices[serviceId] = addr;
     }
@@ -29,5 +33,9 @@ contract MockRegistry {
 
     function registerFeature(bytes32 id, address impl, uint8) external {
         features[id] = impl;
+    }
+
+    function upgradeFeature(bytes32 id, address newImpl) external {
+        features[id] = newImpl;
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,4 +8,4 @@ optimizer_runs = 200
 via_ir = true
 
 gas_reports = ['*']
-no_match_coverage = '.*/mocks/.*|contracts/modules/contests/ContestFactory.sol|contracts/modules/contests/ContestValidator.sol|contracts/modules/marketplace/MarketplaceFactory.sol'
+no_match_coverage = '.*/mocks/.*|contracts/modules/contests/ContestValidator.sol'

--- a/test/foundry/ContestFactory.t.sol
+++ b/test/foundry/ContestFactory.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {ContestFactory} from "contracts/modules/contests/ContestFactory.sol";
+import {ContestEscrow} from "contracts/modules/contests/ContestEscrow.sol";
+import {PrizeInfo, PrizeType} from "contracts/modules/contests/shared/PrizeInfo.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockFeeManager} from "contracts/mocks/MockFeeManager.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {InvalidPrizeData, NotGovernor} from "contracts/errors/Errors.sol";
+import {CoreDefs} from "contracts/interfaces/CoreDefs.sol";
+import {IContestValidator} from "contracts/modules/contests/interfaces/IContestValidator.sol";
+
+contract DummyValidator is IContestValidator {
+    function validatePrize(PrizeInfo calldata) external pure {}
+    function isTokenAllowed(address) external pure returns (bool) { return true; }
+    function isDistributionValid(uint256, uint8) external pure returns (bool) { return true; }
+}
+
+contract ContestFactoryTest is Test {
+    ContestFactory internal factory;
+    MockRegistry internal registry;
+    AccessControlCenter internal acc;
+    MockFeeManager internal fee;
+    TestToken internal token;
+    DummyValidator internal validator;
+
+    bytes32 internal constant MODULE_ID = CoreDefs.CONTEST_MODULE_ID;
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        registry = new MockRegistry();
+        fee = new MockFeeManager();
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(acc.GOVERNOR_ROLE(), address(this));
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        validator = new DummyValidator();
+        registry.setModuleServiceAlias(MODULE_ID, "Validator", address(validator));
+        factory = new ContestFactory(address(registry), address(fee));
+    }
+
+    function _prizes() internal view returns (PrizeInfo[] memory prizes) {
+        prizes = new PrizeInfo[](1);
+        prizes[0] = PrizeInfo({
+            prizeType: PrizeType.MONETARY,
+            token: address(token),
+            amount: 100 ether,
+            distribution: 0,
+            uri: ""
+        });
+    }
+
+    function testCreateContestTransfersFunds() public {
+        PrizeInfo[] memory prizes = _prizes();
+        token.approve(address(factory), 100 ether);
+        address esc = factory.createContest(prizes, "");
+        assertEq(token.balanceOf(esc), 100 ether);
+        assertEq(ContestEscrow(esc).creator(), address(this));
+    }
+
+    function testOnlyGovernor() public {
+        PrizeInfo[] memory prizes = _prizes();
+        address other = address(0x1);
+        vm.prank(other);
+        vm.expectRevert(NotGovernor.selector);
+        factory.createContest(prizes, "");
+    }
+
+    function testInvalidPrizeReverts() public {
+        PrizeInfo[] memory prizes = new PrizeInfo[](1);
+        prizes[0] = PrizeInfo({
+            prizeType: PrizeType.MONETARY,
+            token: address(token),
+            amount: 0,
+            distribution: 0,
+            uri: ""
+        });
+        vm.expectRevert(InvalidPrizeData.selector);
+        factory.createContest(prizes, "");
+    }
+}

--- a/test/foundry/MarketplaceFactory.t.sol
+++ b/test/foundry/MarketplaceFactory.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {MarketplaceFactory} from "contracts/modules/marketplace/MarketplaceFactory.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import {PaymentGatewayNotRegistered, NotFactoryAdmin} from "contracts/errors/Errors.sol";
+
+contract MarketplaceFactoryTest is Test {
+    MarketplaceFactory internal factory;
+    MockRegistry internal registry;
+    MockPaymentGateway internal gateway;
+    AccessControlCenter internal acc;
+
+    bytes32 internal constant FACTORY_ADMIN = keccak256("FACTORY_ADMIN");
+    bytes32 internal constant MODULE_ID = keccak256("Marketplace");
+
+    function setUp() public {
+        registry = new MockRegistry();
+        gateway = new MockPaymentGateway();
+        acc = new AccessControlCenter();
+        acc.initialize(address(this));
+        acc.grantRole(FACTORY_ADMIN, address(this));
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        factory = new MarketplaceFactory(address(registry), address(gateway));
+    }
+
+    function testCreateMarketplaceRegistersAndReturnsAddress() public {
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+        uint256 ts = 1234;
+        vm.warp(ts);
+        bytes32 id = keccak256(abi.encodePacked("Marketplace:", address(factory), ts));
+        address m = factory.createMarketplace();
+        assertEq(registry.features(id), m);
+        assertEq(registry.getModuleServiceByAlias(id, "PaymentGateway"), address(gateway));
+    }
+
+    function testCreateMarketplaceNoGateway() public {
+        vm.expectRevert(PaymentGatewayNotRegistered.selector);
+        factory.createMarketplace();
+    }
+
+    function testOnlyFactoryAdmin() public {
+        registry.setModuleServiceAlias(MODULE_ID, "PaymentGateway", address(gateway));
+        address other = address(0x1);
+        vm.prank(other);
+        vm.expectRevert(NotFactoryAdmin.selector);
+        factory.createMarketplace();
+    }
+}


### PR DESCRIPTION
## Summary
- add foundry tests for `MarketplaceFactory` and `ContestFactory`
- extend `MockRegistry` with missing helper functions
- update `foundry.toml` coverage exclusions

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_68625ffa2df8832397fe003c244fb463