### PR TITLE
Expand Hardhat test coverage

### DIFF
--- a/test/hardhat/cloneFactory.test.ts
+++ b/test/hardhat/cloneFactory.test.ts
@@ -42,4 +42,14 @@ describe("CloneFactory", function () {
     const c2 = await factory.clone(await template.getAddress(), salt2, initData);
     expect(c1).to.not.equal(c2);
   });
+
+  it("returns existing clone on subsequent calls", async () => {
+    const salt = ethers.keccak256(ethers.toUtf8Bytes("repeat"));
+    const initData = new ethers.Interface(["function init(uint256)"]).encodeFunctionData("init", [123]);
+    const predicted = await factory.predict(await template.getAddress(), salt);
+    await factory.clone(await template.getAddress(), salt, initData);
+    await factory.clone(await template.getAddress(), salt, "0x");
+    const clone = await ethers.getContractAt("DummyTemplate", predicted);
+    expect(await clone.value()).to.equal(123n);
+  });
 });

--- a/test/hardhat/contestEscrow.test.ts
+++ b/test/hardhat/contestEscrow.test.ts
@@ -5,6 +5,7 @@ describe("ContestEscrow", function () {
   let token: any;
   let escrow: any;
   let deployer: any, creator: any, w1: any, w2: any;
+  let deadline: number;
 
   beforeEach(async () => {
     [deployer, creator, w1, w2] = await ethers.getSigners();
@@ -22,7 +23,7 @@ describe("ContestEscrow", function () {
 
     const Escrow = await ethers.getContractFactory("ContestEscrow");
     const latestBlock = await ethers.provider.getBlock("latest");
-    const deadline = (latestBlock!).timestamp + 86400;
+    deadline = (latestBlock!).timestamp + 86400;
     escrow = await Escrow.connect(deployer).deploy(creator.address, prizes, await registry.getAddress(), 0, await token.getAddress(), deadline);
     await token.transfer(await escrow.getAddress(), ethers.parseEther("150"));
   });
@@ -32,5 +33,37 @@ describe("ContestEscrow", function () {
     expect(await token.balanceOf(w1.address)).to.equal(ethers.parseEther("100"));
     expect(await token.balanceOf(w2.address)).to.equal(ethers.parseEther("50"));
     expect(await escrow.finalized()).to.equal(true);
+  });
+
+  it("reverts with wrong winners count", async () => {
+    await expect(
+      escrow.connect(creator).finalize([w1.address], 0, 0)
+    ).to.be.revertedWithCustomError(escrow, "WrongWinnersCount");
+  });
+
+  it("creator can cancel and retrieve funds", async () => {
+    await escrow.connect(creator).cancel();
+    expect(await token.balanceOf(creator.address)).to.equal(
+      ethers.parseEther("150")
+    );
+    expect(await escrow.finalized()).to.equal(true);
+  });
+
+  it("emergency withdraw after grace period", async () => {
+    await ethers.provider.send("evm_setNextBlockTimestamp", [
+      deadline + 30 * 24 * 60 * 60 + 1,
+    ]);
+    await ethers.provider.send("evm_mine", []);
+    await escrow.connect(creator).emergencyWithdraw();
+    expect(await token.balanceOf(creator.address)).to.equal(
+      ethers.parseEther("150")
+    );
+    expect(await escrow.finalized()).to.equal(true);
+  });
+
+  it("emergency withdraw before grace period reverts", async () => {
+    await expect(
+      escrow.connect(creator).emergencyWithdraw()
+    ).to.be.revertedWithCustomError(escrow, "GracePeriodNotExpired");
   });
 });

--- a/test/hardhat/nftManager.test.ts
+++ b/test/hardhat/nftManager.test.ts
@@ -61,4 +61,24 @@ describe("NFTManager", function () {
       nft.mintBatch(recipients, uris, false)
     ).to.be.revertedWithCustomError(nft, "BatchTooLarge");
   });
+
+  it("allows transfer after approval", async () => {
+    await nft.mint(user.address, "u", false);
+    await nft.connect(user).approve(other.address, 1);
+    await expect(
+      nft.connect(other).transferFrom(user.address, other.address, 1)
+    )
+      .to.emit(nft, "Transfer")
+      .withArgs(user.address, other.address, 1n);
+    expect(await nft.balanceOf(other.address)).to.equal(1n);
+  });
+
+  it("non owner cannot burn", async () => {
+    await nft.mint(user.address, "u", false);
+    await expect(
+      nft.connect(user).burn(1)
+    )
+      .to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount")
+      .withArgs(user.address);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `ContestEscrow` tests with edge cases
- add more scenarios for `NFTManager`
- verify `CloneFactory` behaviour for repeated clone calls

## Testing
- `npx hardhat test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_686265932fe883239c78d6bb730195f6