### PR TITLE
Add Hardhat gas reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Run Hardhat tests
         run: npx hardhat test
 
+      # 8.5) Generate Hardhat gas report
+      - name: Hardhat gas report
+        run: npm run gasreport
+
       # 9) Run showcase scripts
       - name: Run showcase scripts
         run: |

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomicfoundation/hardhat-ignition";
 import "@typechain/hardhat";
 import "@nomicfoundation/hardhat-network-helpers";
 import "solidity-coverage";
+import "hardhat-gas-reporter";
 
 const config: HardhatUserConfig = {
     defaultNetwork: "hardhat",
@@ -47,6 +48,11 @@ const config: HardhatUserConfig = {
     mocha: {
         timeout: 120000,
         reporter: 'spec'
+    },
+    gasReporter: {
+        enabled: process.env.REPORT_GAS === 'true',
+        currency: 'USD',
+        coinmarketcap: process.env.COINMARKETCAP_API_KEY || '',
     },
     typechain: {
         outDir: "typechain-types",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,17 @@
     "verify:mainnet": "npx hardhat ignition verify mainnet-deployment",
     "lint": "prettier --check \"contracts/**/*.sol\"",
     "lint:fix": "prettier --write \"contracts/**/*.sol\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "gasreport": "REPORT_GAS=true npx hardhat test"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.9",
     "@nomicfoundation/hardhat-ignition": "^0.15.0",
+    "@nomicfoundation/hardhat-ignition-ethers": "^0.15.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "@nomicfoundation/hardhat-verify": "^2.0.0",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "@types/chai": "^4.3.0",
@@ -29,6 +33,7 @@
     "ethers": "^6.14.4",
     "glob": "^11.0.3",
     "hardhat": "^2.25.0",
+    "hardhat-gas-reporter": "^1.0.9",
     "husky": "^8.0.0",
     "mocha": "^10.8.2",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary
- add `hardhat-gas-reporter` dependency and script
- configure `hardhat.config.ts` to enable gas reports when `REPORT_GAS=true`
- run gas reporter in CI workflow

## Testing
- `npm run gasreport`


------
https://chatgpt.com/codex/tasks/task_e_686267a06ee88323a466e4a3d0556413