### PR TITLE
Add stress tests for core modules

### DIFF
--- a/test/foundry/ContestEscrowStress.t.sol
+++ b/test/foundry/ContestEscrowStress.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {ContestEscrow} from "contracts/modules/contests/ContestEscrow.sol";
+import {PrizeInfo, PrizeType} from "contracts/modules/contests/shared/PrizeInfo.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract ContestEscrowStressTest is Test {
+    ContestEscrow internal escrow;
+    TestToken internal token;
+    address internal creator = address(0xCAFE);
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        uint256 count = 25;
+        PrizeInfo[] memory prizes = new PrizeInfo[](count);
+        for (uint256 i; i < count; ++i) {
+            prizes[i] = PrizeInfo({
+                prizeType: PrizeType.MONETARY,
+                token: address(token),
+                amount: 1 ether,
+                distribution: 0,
+                uri: ""
+            });
+        }
+        MockRegistry reg = new MockRegistry();
+        escrow = new ContestEscrow(creator, prizes, address(reg), 0, address(token), block.timestamp + 1 days);
+        token.transfer(address(escrow), count * 1 ether);
+    }
+
+    function testFinalizeInBatches() public {
+        uint256 count = 25;
+        address[] memory winners = new address[](count);
+        for (uint256 i; i < count; ++i) {
+            winners[i] = address(uint160(i + 100));
+        }
+
+        vm.prank(creator);
+        escrow.finalize(winners, 0, 0);
+        assertEq(escrow.processedWinners(), 20);
+        assertFalse(escrow.finalized());
+
+        vm.prank(creator);
+        escrow.finalize(winners, 0, 0);
+        assertEq(escrow.processedWinners(), count);
+        assertTrue(escrow.finalized());
+        assertEq(token.balanceOf(winners[0]), 1 ether);
+        assertEq(token.balanceOf(winners[count - 1]), 1 ether);
+    }
+}
+

--- a/test/foundry/MarketplaceStress.t.sol
+++ b/test/foundry/MarketplaceStress.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {Marketplace} from "contracts/modules/marketplace/Marketplace.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenter} from "contracts/mocks/MockAccessControlCenter.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+
+contract MarketplaceStressTest is Test {
+    Marketplace internal market;
+    MockRegistry internal registry;
+    MockAccessControlCenter internal acc;
+    MockPaymentGateway internal gateway;
+    TestToken internal token;
+
+    address internal seller = address(0x1);
+    address internal buyer = address(0x2);
+
+    function setUp() public {
+        token = new TestToken("T", "T");
+        registry = new MockRegistry();
+        acc = new MockAccessControlCenter();
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        gateway = new MockPaymentGateway();
+        bytes32 moduleId = keccak256("MarketStress");
+        registry.setModuleServiceAlias(moduleId, "PaymentGateway", address(gateway));
+        market = new Marketplace(address(registry), address(gateway), moduleId);
+        token.transfer(buyer, 1000 ether);
+    }
+
+    function testStressListAndBuy() public {
+        uint256 count = 50;
+        uint256 price = 1 ether;
+        for (uint256 i; i < count; ++i) {
+            vm.prank(seller);
+            market.list(address(token), price);
+        }
+
+        vm.startPrank(buyer);
+        token.approve(address(gateway), price * count);
+        for (uint256 i; i < count; ++i) {
+            market.buy(i);
+            (, , , bool active) = market.listings(i);
+            assertFalse(active);
+        }
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(seller), price * count);
+        assertEq(token.balanceOf(buyer), 1000 ether - price * count);
+    }
+}
+

--- a/test/foundry/SubscriptionManagerStress.t.sol
+++ b/test/foundry/SubscriptionManagerStress.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {SubscriptionManager} from "contracts/modules/subscriptions/SubscriptionManager.sol";
+import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
+import {MockAccessControlCenterAuto} from "contracts/mocks/MockAccessControlCenterAuto.sol";
+import {MockPaymentGateway} from "contracts/mocks/MockPaymentGateway.sol";
+import {TestToken} from "contracts/mocks/TestToken.sol";
+import {SignatureLib} from "contracts/lib/SignatureLib.sol";
+
+contract SubscriptionManagerStressTest is Test {
+    SubscriptionManager internal sub;
+    MockRegistry internal registry;
+    MockAccessControlCenterAuto internal acc;
+    MockPaymentGateway internal gateway;
+    TestToken internal token;
+
+    address internal merchant;
+    uint256 internal merchantPk = 1;
+    address internal keeper = address(0xCAFE);
+
+    function setUp() public {
+        merchant = vm.addr(merchantPk);
+        token = new TestToken("T", "T");
+        registry = new MockRegistry();
+        acc = new MockAccessControlCenterAuto();
+        registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
+        gateway = new MockPaymentGateway();
+        bytes32 moduleId = keccak256("SubStress");
+        registry.setModuleServiceAlias(moduleId, "PaymentGateway", address(gateway));
+        sub = new SubscriptionManager(address(registry), address(gateway), moduleId);
+    }
+
+    function _defaultPlan() internal view returns (SignatureLib.Plan memory plan) {
+        plan = SignatureLib.Plan({
+            chainIds: new uint256[](1),
+            price: 1 ether,
+            period: 1 days,
+            token: address(token),
+            merchant: merchant,
+            salt: 1,
+            expiry: 0
+        });
+        plan.chainIds[0] = block.chainid;
+    }
+
+    function _sign(bytes32 digest) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(merchantPk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testChargeBatchStress() public {
+        uint256 count = 25;
+        SignatureLib.Plan memory plan = _defaultPlan();
+        bytes32 planHash = sub.hashPlan(plan);
+        bytes memory sig = _sign(planHash);
+        address[] memory users = new address[](count);
+        for (uint256 i; i < count; ++i) {
+            address user = address(uint160(i + 10));
+            users[i] = user;
+            token.transfer(user, 2 ether);
+            vm.startPrank(user);
+            token.approve(address(gateway), 2 ether);
+            sub.subscribe(plan, sig, "");
+            vm.stopPrank();
+        }
+
+        vm.prank(address(this));
+        sub.setBatchLimit(10);
+
+        (uint256 firstBilling, ) = sub.subscribers(users[0]);
+        vm.warp(firstBilling + 1);
+        vm.prank(keeper);
+        sub.chargeBatch(users);
+
+        assertEq(token.balanceOf(merchant), (count + 10) * 1 ether);
+        (uint256 nextBilling, ) = sub.subscribers(users[0]);
+        assertEq(nextBilling, firstBilling + plan.period);
+        (nextBilling, ) = sub.subscribers(users[count - 1]);
+        assertEq(nextBilling, firstBilling); // unchanged
+    }
+}
+


### PR DESCRIPTION
## Summary
- add stress tests for Marketplace, SubscriptionManager, and ContestEscrow modules

## Testing
- `forge test -vv`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68626abe72dc83238637ee298a0bad21