### PR TITLE
Fix ignition scripts and document deployment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@
    npx hardhat run scripts/showcase-all.ts --network localhost
    ```
 
+## Deployment order
+
+The Ignition modules deploy contracts in the following sequence:
+
+1. **CoreModule** – deploys `AccessControlCenter`, `Registry`, `CoreFeeManager`,
+   `PaymentGateway`, `MultiValidator`, `MarketplaceFactory` and a `MockPriceFeed`.
+   The marketplace module is registered along with validator and gateway services.
+2. **LocalDeploy** – in addition to the core contracts it deploys a test ERC-20
+   token and the contest module (`ContestFactory` with its validator) for local
+   development.
+3. **PublicDeploy** – similar to `LocalDeploy` but omits the test token and is
+   intended for testnets or mainnet.
+
+Use the provided npm scripts to deploy:
+
+```bash
+npm run deploy:local     # local Hardhat network
+npm run deploy:sepolia   # Sepolia testnet
+npm run deploy:mainnet   # Ethereum mainnet
+```
+
 ## Как запустить Foundry
 
 1. Установите инструментарий Foundry:

--- a/ignition/modules/CoreModule.ts
+++ b/ignition/modules/CoreModule.ts
@@ -11,6 +11,9 @@ const CoreModule = buildModule("CoreModule", (m) => {
   const PAYMENT_GATEWAY_SERVICE = ethers.keccak256(
     ethers.toUtf8Bytes("PaymentGateway")
   );
+  const FEE_MANAGER_SERVICE = ethers.keccak256(
+    ethers.toUtf8Bytes("CoreFeeManager")
+  );
   const VALIDATOR_SERVICE = ethers.keccak256(
     ethers.toUtf8Bytes("SERVICE_VALIDATOR")
   );
@@ -22,10 +25,11 @@ const CoreModule = buildModule("CoreModule", (m) => {
   m.call(feeManager, "initialize", [access]);
 
   m.call(registry, "setCoreService", [ACCESS_SERVICE, access]);
-  m.call(registry, "setCoreService", [PAYMENT_GATEWAY_SERVICE, feeManager]);
+  m.call(registry, "setCoreService", [FEE_MANAGER_SERVICE, feeManager]);
 
   const gateway = m.contract("PaymentGateway", []);
   m.call(gateway, "initialize", [access, registry, feeManager]);
+  m.call(registry, "setCoreService", [PAYMENT_GATEWAY_SERVICE, gateway]);
 
   const tokenValidator = m.contract("MultiValidator", []);
   m.call(tokenValidator, "initialize", [access]);
@@ -33,6 +37,7 @@ const CoreModule = buildModule("CoreModule", (m) => {
   const marketplaceFactory = m.contract("MarketplaceFactory", [registry, gateway]);
   m.call(registry, "registerFeature", [MARKETPLACE_ID, marketplaceFactory, 0]);
   m.call(registry, "setModuleService", [MARKETPLACE_ID, VALIDATOR_SERVICE, tokenValidator]);
+  m.call(registry, "setModuleServiceAlias", [MARKETPLACE_ID, "PaymentGateway", gateway]);
 
   const priceFeed = m.contract("MockPriceFeed", []);
 


### PR DESCRIPTION
## Summary
- register fee manager and payment gateway correctly in CoreModule
- add service alias for PaymentGateway when registering Marketplace module
- document module deployment order in the README

## Testing
- `npm test` *(fails: requires network access to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68626b05094483238cf5e744b78235fd