### PR TITLE
Add docs and API stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+## [Unreleased]
+- Added architecture, testing and migration documentation.
+- Created API stubs describing contracts and scripts.
+- Added this changelog file.
+
+## [2025-06-30]
+- Added stress tests for core modules.
+- Fixed Ignition deployment flow.
+- Integrated Hardhat gas reporter.
+- Added fuzz tests for `MultiValidator`.
+- Added additional Hardhat and Foundry tests.

--- a/api/contracts.md
+++ b/api/contracts.md
@@ -1,0 +1,15 @@
+# Contract Summary
+
+A high level overview of the main Solidity contracts. See `contracts/` for sources.
+
+- **AccessControlCenter** – centralized permissions management.
+- **Registry** – keeps module and service addresses.
+- **CoreFeeManager** – collects protocol fees.
+- **PaymentGateway** – entry point for all payments.
+- **MultiValidator** – aggregates validation strategies.
+- **GasSubsidyManager** – optional gas subsidy mechanism.
+- **ContestFactory** – deploys new ContestEscrow contracts.
+- **ContestEscrow** – stores prize funds and distributes rewards.
+- **Marketplace** – basic marketplace for item sales.
+- **MarketplaceFactory** – deploys marketplace instances.
+- **SubscriptionManager** – recurring subscription management.

--- a/api/scripts.md
+++ b/api/scripts.md
@@ -1,0 +1,8 @@
+# Script Summary
+
+Utility scripts are located in the `scripts/` directory.
+
+- **demo/** – examples demonstrating contests, marketplace and subscriptions.
+- **showcase-marketplace.ts** – runs a short marketplace showcase.
+- **helper.ts** – common helpers used by demo scripts.
+- **check-coverage.sh** – helper script for verifying Foundry coverage thresholds.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Overview
+
+This folder will contain generated documentation for the solidity contracts and TypeScript helpers. Full API docs are not yet available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+This project consists of a small core with optional modules that extend the base functionality. All modules share the same `AccessControlCenter` for role management and a `Registry` for service discovery.
+
+## Core contracts
+
+- **AccessControlCenter** – centralized RBAC and permissions.
+- **Registry** – registry of modules and shared services.
+- **CoreFeeManager** – collects protocol and module fees.
+- **PaymentGateway** – handles all user payments.
+- **MultiValidator** – aggregator for token and address validators.
+- **GasSubsidyManager** – subsidizes transaction gas for certain users.
+
+## Modules
+
+- **ContestFactory & ContestEscrow** – create contests and manage prize payouts.
+- **Marketplace & MarketplaceFactory** – sell items and subscriptions.
+- **SubscriptionManager** – track subscription status and recurring charges.
+
+Each module registers its contracts in the `Registry` and relies on the gateway and validators from the core. New modules can be integrated by deploying their contracts and adding them to the registry.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,20 @@
+# Migrations
+
+Contract deployment is handled via Hardhat Ignition modules. The main sequence is defined in `ignition/modules/CoreModule.ts` with additional setups for local and public networks.
+
+## Deploy locally
+
+```
+npm run deploy:local
+```
+
+This deploys core contracts plus example modules on a Hardhat node.
+
+## Deploy to a testnet or mainnet
+
+```
+npm run deploy:sepolia   # Sepolia testnet
+npm run deploy:mainnet   # Ethereum mainnet
+```
+
+After deployment, register each module and its services in the `Registry` so other modules can discover them.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,19 @@
+# Testing
+
+Two test suites exist: Foundry and Hardhat.
+
+## Foundry
+
+```
+forge test
+```
+
+Runs Solidity based unit and fuzz tests located in `test/foundry/`.
+
+## Hardhat
+
+```
+npm test
+```
+
+Executes JavaScript/TypeScript tests under `test/hardhat/` and is also used for gas reports and coverage.


### PR DESCRIPTION
## Summary
- add architecture, testing, migrations documentation
- create `api/` directory with contract and script stubs
- include a stub `docs/api/` folder
- add project `CHANGELOG`

## Testing
- `forge test` *(fails: failed to resolve openzeppelin contracts)*
- `npm test` *(fails: needs to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_686272b69c448323b66715b06b6f7e88