### PR TITLE
Fix gitignore for chainlink library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ node_modules
 
 # Foundry build artifacts
 /lib
+# Keep required libraries (Chainlink)
+!lib/chainlink/
+!lib/chainlink/**
 /out
 
 # Hardhat Ignition default folder for deployments against a local node

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
    cd evmcontest
    npm install
    ```
+   > The `lib` directory stores external libraries. Only `lib/chainlink` is tracked in Git; other subfolders may be ignored.
 2. Create a `.env` file:
    ```env
    PRIVATE_KEY=your_private_key


### PR DESCRIPTION
## Summary
- keep lib/chainlink in version control
- mention that only lib/chainlink is tracked and other libs may be ignored

## Testing
- `npm test` *(fails: Hardhat requires local install)*

------
https://chatgpt.com/codex/tasks/task_e_686272c7c4948323a5566940fe10b5aa