### PR TITLE
Fix demo fee collection

### DIFF
--- a/scripts/demo/marketplace-demo.ts
+++ b/scripts/demo/marketplace-demo.ts
@@ -47,13 +47,6 @@ async function main() {
     await gateway.getAddress()
   );
 
-  await safeExecute("configure commission", async () => {
-    await feeManager.setPercentFee(
-      CONSTANTS.MARKETPLACE_ID,
-      await token.getAddress(),
-      500n
-    );
-  });
 
   // Grant required roles
   await ensureRoles(acl, deployer.address);
@@ -70,6 +63,16 @@ async function main() {
     marketplaceAddress
   );
   console.log(`Marketplace deployed: ${marketplaceAddress}\n`);
+
+  // Configure commission for the deployed marketplace using its module id
+  const moduleId = await marketplace.MODULE_ID();
+  await safeExecute("configure commission", async () => {
+    await feeManager.setPercentFee(
+      moduleId,
+      await token.getAddress(),
+      500n
+    );
+  });
 
   // Create listing
   const price = ethers.parseEther("10");
@@ -95,13 +98,13 @@ async function main() {
   console.log(`Buyer balance:  ${ethers.formatEther(buyerBal)} tokens`);
 
   const fees = await feeManager.collectedFees(
-    CONSTANTS.MARKETPLACE_ID,
+    moduleId,
     await token.getAddress()
   );
   console.log(`Collected fees: ${ethers.formatEther(fees)} tokens`);
   if (fees > 0n) {
     await feeManager.withdrawFees(
-      CONSTANTS.MARKETPLACE_ID,
+      moduleId,
       await token.getAddress(),
       deployer.address
     );

--- a/scripts/demo/utils/deployer.ts
+++ b/scripts/demo/utils/deployer.ts
@@ -118,13 +118,13 @@ export async function deployCore(): Promise<{
 
   // 7. Деплой платежного шлюза
   const gateway = await safeExecute("деплой платежного шлюза", async () => {
-    // Пробуем сначала мок, затем реальный шлюз
+    // Сначала пытаемся использовать реальный шлюз, затем fallback на мок
     let Gateway;
     try {
-      Gateway = await ethers.getContractFactory("MockPaymentGateway");
-    } catch (error) {
-      console.log('MockPaymentGateway не найден, пробуем PaymentGateway...');
       Gateway = await ethers.getContractFactory("PaymentGateway");
+    } catch (error) {
+      console.log('PaymentGateway не найден, пробуем MockPaymentGateway...');
+      Gateway = await ethers.getContractFactory("MockPaymentGateway");
     }
 
     const gateway = await Gateway.deploy();


### PR DESCRIPTION
## Summary
- use `PaymentGateway` by default when deploying core services
- configure marketplace fees using instance `MODULE_ID`

## Testing
- `npm test` *(fails: Need to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_6862eb5eaa5c8323b07b28614e059dd3