### PR TITLE
Fix buy function call ambiguity

### DIFF
--- a/scripts/demo/utils/listing.ts
+++ b/scripts/demo/utils/listing.ts
@@ -246,9 +246,12 @@ export async function purchaseListing(marketplace: any, token: any, buyer: any, 
         // функцию `buy(uint256)` для ончейн-листинга, поэтому используем её
         // напрямую, не пытаясь определить сложные сигнатуры.
         try {
-            let tx = await marketplace.connect(buyer).buy(listingId, {
-                gasLimit: 1000000
-            });
+            // Указываем полную сигнатуру функции, чтобы исключить неоднозначность
+            let tx = await marketplace
+                .connect(buyer)
+                ["buy(uint256)"](listingId, {
+                    gasLimit: 1000000
+                });
             console.log("Транзакция отправлена:", tx.hash);
             await tx.wait();
 

--- a/scripts/showcase-marketplace.ts
+++ b/scripts/showcase-marketplace.ts
@@ -714,7 +714,8 @@ async function setupDemoEnvironment(): Promise<{
       const marketplaceForBuyer = await ethers.getContractAt("Marketplace", marketplaceAddress, buyer);
 
       // Покупаем товар
-      const tx = await marketplaceForBuyer.buy(listingId);
+      // Указываем явную сигнатуру, чтобы избежать неоднозначности в ethers.js
+      const tx = await marketplaceForBuyer["buy(uint256)"](listingId);
       console.log(`Транзакция покупки отправлена: ${tx.hash}`);
       const receipt = await tx.wait();
       console.log("Транзакция покупки подтверждена");


### PR DESCRIPTION
## Summary
- avoid ambiguous overload by using explicit signature for `buy`

## Testing
- `npm test` *(fails: Need to install Hardhat packages)*

------
https://chatgpt.com/codex/tasks/task_e_6862f6ce91a48323af1c75246571fe44