### PR TITLE
Add reentrancy protection

### DIFF
--- a/contracts/shared/NFTManager.sol
+++ b/contracts/shared/NFTManager.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.28;
 import '@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 import '../errors/Errors.sol';
+import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 
-contract NFTManager is ERC721URIStorage, Ownable {
+contract NFTManager is ERC721URIStorage, Ownable, ReentrancyGuard {
     uint256 public tokenIdCounter;
     uint256 public constant MAX_BATCH_MINT = 50;
     mapping(uint256 => bool) public isSoulbound;
@@ -19,7 +20,7 @@ contract NFTManager is ERC721URIStorage, Ownable {
     /// @param uri Token metadata URI
     /// @param soulbound Whether token is soulbound
     /// @return tokenId Newly minted token id
-    function mint(address to, string calldata uri, bool soulbound) external onlyOwner returns (uint256) {
+    function mint(address to, string calldata uri, bool soulbound) external onlyOwner nonReentrant returns (uint256) {
         uint256 tokenId = ++tokenIdCounter;
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
@@ -46,7 +47,7 @@ contract NFTManager is ERC721URIStorage, Ownable {
     /// @param recipients Addresses receiving tokens
     /// @param uris Metadata URIs
     /// @param soulbound Whether minted tokens are soulbound
-    function mintBatch(address[] calldata recipients, string[] calldata uris, bool soulbound) external onlyOwner {
+    function mintBatch(address[] calldata recipients, string[] calldata uris, bool soulbound) external onlyOwner nonReentrant {
         if (recipients.length != uris.length) revert LengthMismatch();
         if (recipients.length > MAX_BATCH_MINT) revert BatchTooLarge();
         for (uint256 i = 0; i < recipients.length; i++) {


### PR DESCRIPTION
## Summary
- protect marketplace purchases from reentrancy
- guard subscription functions against reentrancy
- make NFT minting functions nonReentrant

## Testing
- `npx hardhat compile` *(fails: Need to install the following packages: hardhat@2.25.0)*

------
https://chatgpt.com/codex/tasks/task_e_6862fd05da2483238bb4f1f2f59e7a75