### PR TITLE
Fix slither issues

### DIFF
--- a/contracts/core/AccessControlCenter.sol
+++ b/contracts/core/AccessControlCenter.sol
@@ -7,6 +7,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '../errors/Errors.sol';
 
 contract AccessControlCenter is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     // Roles
     bytes32 public constant FEATURE_OWNER_ROLE = keccak256('FEATURE_OWNER_ROLE');
     bytes32 public constant OPERATOR_ROLE = keccak256('OPERATOR_ROLE');

--- a/contracts/core/CoreFeeManager.sol
+++ b/contracts/core/CoreFeeManager.sol
@@ -12,6 +12,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '../errors/Errors.sol';
 
 contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, PausableUpgradeable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     using Address for address payable;
     using SafeERC20 for IERC20;
 
@@ -55,15 +59,14 @@ contract CoreFeeManager is Initializable, ReentrancyGuardUpgradeable, PausableUp
     /// @notice Calculate and collect fee
     /// @param moduleId Module identifier
     /// @param token Fee token
-    /// @param payer Address paying the fee
     /// @param amount Payment amount
     /// @return feeAmount Actual fee charged
     function collect(
         bytes32 moduleId,
         address token,
-        address payer,
         uint256 amount
     ) external onlyFeatureOwner nonReentrant whenNotPaused returns (uint256 feeAmount) {
+        address payer = msg.sender;
         if (isZeroFeeAddress[moduleId][payer]) return 0;
 
         uint16 pFee = percentFee[moduleId][token];

--- a/contracts/core/EventRouter.sol
+++ b/contracts/core/EventRouter.sol
@@ -7,6 +7,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '../errors/Errors.sol';
 
 contract EventRouter is Initializable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     AccessControlCenter public access;
 
     enum EventKind {

--- a/contracts/core/GasSubsidyManager.sol
+++ b/contracts/core/GasSubsidyManager.sol
@@ -4,9 +4,15 @@ pragma solidity ^0.8.28;
 import './AccessControlCenter.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts/utils/Address.sol';
 import '../errors/Errors.sol';
 
 contract GasSubsidyManager is Initializable, UUPSUpgradeable {
+    using Address for address payable;
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     AccessControlCenter public access;
 
     // moduleId => user => whether gas coverage is allowed
@@ -102,7 +108,7 @@ contract GasSubsidyManager is Initializable, UUPSUpgradeable {
         if (gasUsed > limit / price) revert ExceedsRefundLimit();
         uint256 refund = price * gasUsed;
         if (address(this).balance < refund) revert InsufficientBalance();
-        relayer.transfer(refund);
+        relayer.sendValue(refund);
         emit GasRefunded(moduleId, relayer, refund);
     }
 

--- a/contracts/core/MultiValidator.sol
+++ b/contracts/core/MultiValidator.sol
@@ -11,6 +11,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 
 contract MultiValidator is Initializable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     AccessControlCenter public access;
 
     // token => allowed

--- a/contracts/core/PaymentGateway.sol
+++ b/contracts/core/PaymentGateway.sol
@@ -18,6 +18,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 
 contract PaymentGateway is Initializable, ReentrancyGuardUpgradeable, PausableUpgradeable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     using Address for address payable;
     using SafeERC20 for IERC20;
 
@@ -92,7 +96,7 @@ contract PaymentGateway is Initializable, ReentrancyGuardUpgradeable, PausableUp
 
         IERC20(token).safeTransferFrom(payer, address(this), amount);
         IERC20(token).forceApprove(address(feeManager), amount);
-        uint256 fee = feeManager.collect(moduleId, token, address(this), amount);
+        uint256 fee = feeManager.collect(moduleId, token, amount);
         IERC20(token).forceApprove(address(feeManager), 0);
         netAmount = amount - fee;
         IERC20(token).safeTransfer(msg.sender, netAmount);

--- a/contracts/core/Registry.sol
+++ b/contracts/core/Registry.sol
@@ -7,6 +7,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '../errors/Errors.sol';
 
 contract Registry is Initializable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     /// @dev Storage for feature information
     struct Feature {
         address implementation;

--- a/contracts/core/TokenRegistry.sol
+++ b/contracts/core/TokenRegistry.sol
@@ -7,6 +7,10 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '../errors/Errors.sol';
 
 contract TokenRegistry is Initializable, UUPSUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
     AccessControlCenter public access;
 
     // moduleId => token => allowed

--- a/contracts/interfaces/core/ICoreFeeManager.sol
+++ b/contracts/interfaces/core/ICoreFeeManager.sol
@@ -5,7 +5,6 @@ interface ICoreFeeManager {
     function collect(
         bytes32 moduleId,
         address token,
-        address payer,
         uint256 amount
     ) external returns (uint256 feeAmount);
 

--- a/scripts/demo/utils/contest.ts
+++ b/scripts/demo/utils/contest.ts
@@ -209,6 +209,6 @@ export async function finalizeContest(
   winners: string[]
 ): Promise<void> {
   const escrow = await ethers.getContractAt("ContestEscrow", contestAddress);
-  const tx = await escrow.finalize(winners, 0n, 0n);
+  const tx = await escrow.finalize(winners, 0n);
   await tx.wait();
 }

--- a/test/foundry/AccessControlCenter.t.sol
+++ b/test/foundry/AccessControlCenter.t.sol
@@ -48,9 +48,7 @@ contract AccessControlCenterTest is Test {
 
     function testUpgradeOnImplementationFails() public {
         AccessControlCenter impl = new AccessControlCenter();
-        impl.initialize(admin);
         AccessControlCenter newImpl = new AccessControlCenter();
-        vm.prank(admin);
         vm.expectRevert(UUPSUpgradeable.UUPSUnauthorizedCallContext.selector);
         impl.upgradeToAndCall(address(newImpl), bytes(""));
     }

--- a/test/foundry/AccessManagedTestSuite.sol
+++ b/test/foundry/AccessManagedTestSuite.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import "contracts/shared/AccessManaged.sol";
 import "contracts/core/AccessControlCenter.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // Мок-контракт для тестирования AccessManaged
 contract MockAccessManaged is AccessManaged {
@@ -29,9 +30,11 @@ contract AccessManagedTest is Test {
     function setUp() public {
         vm.startPrank(admin);
         
-        // Деплоим ACL
-        acl = new AccessControlCenter();
-        acl.initialize(admin);
+        // Deploy ACL via proxy
+        AccessControlCenter impl = new AccessControlCenter();
+        bytes memory data = abi.encodeCall(AccessControlCenter.initialize, admin);
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        acl = AccessControlCenter(address(proxy));
         
         // Даем админу роль DEFAULT_ADMIN_ROLE
         bytes32 adminRole = acl.DEFAULT_ADMIN_ROLE();

--- a/test/foundry/BaseFactory.t.sol
+++ b/test/foundry/BaseFactory.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import {BaseFactory} from "contracts/shared/BaseFactory.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
 import {NotFactoryAdmin} from "contracts/errors/Errors.sol";
 
@@ -32,8 +33,10 @@ contract BaseFactoryTest is Test {
     bytes32 internal constant MODULE_ID = keccak256("Module");
 
     function setUp() public {
-        acc = new AccessControlCenter();
-        acc.initialize(address(this));
+        AccessControlCenter impl = new AccessControlCenter();
+        bytes memory data = abi.encodeCall(AccessControlCenter.initialize, address(this));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        acc = AccessControlCenter(address(proxy));
         acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
         acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(1));
 

--- a/test/foundry/ContestEscrow.t.sol
+++ b/test/foundry/ContestEscrow.t.sol
@@ -42,7 +42,7 @@ contract ContestEscrowTest is Test {
         winners[0] = w1;
         winners[1] = w2;
         vm.prank(creator);
-        escrow.finalize(winners, 0, 0);
+        escrow.finalize(winners, 0);
         assertEq(token.balanceOf(w1), 100 ether);
         assertEq(token.balanceOf(w2), 50 ether);
         assertTrue(escrow.finalized());
@@ -103,7 +103,7 @@ contract ContestEscrowTest is Test {
         winners[1] = w2;
         winners[2] = address(0x3);
         vm.prank(creator);
-        esc.finalize(winners, 0, 0);
+        esc.finalize(winners, 0);
         assertEq(token.balanceOf(w1), 30 ether);
         assertEq(token.balanceOf(w2), 20 ether);
     }
@@ -116,7 +116,7 @@ contract ContestEscrowTest is Test {
         address[] memory winners = new address[](1);
         winners[0] = w1;
         vm.prank(creator);
-        esc.finalize(winners, 0, 0);
+        esc.finalize(winners, 0);
         assertTrue(esc.finalized());
     }
 
@@ -131,7 +131,7 @@ contract ContestEscrowTest is Test {
         winners[0] = w1;
         winners[1] = w2;
         vm.prank(creator);
-        esc.finalize(winners, 0, 0);
+        esc.finalize(winners, 0);
         assertEq(token.balanceOf(w1), 1 ether);
         assertTrue(esc.finalized());
     }

--- a/test/foundry/ContestEscrowStress.t.sol
+++ b/test/foundry/ContestEscrowStress.t.sol
@@ -38,12 +38,12 @@ contract ContestEscrowStressTest is Test {
         }
 
         vm.prank(creator);
-        escrow.finalize(winners, 0, 0);
+        escrow.finalize(winners, 0);
         assertEq(escrow.processedWinners(), 20);
         assertFalse(escrow.finalized());
 
         vm.prank(creator);
-        escrow.finalize(winners, 0, 0);
+        escrow.finalize(winners, 0);
         assertEq(escrow.processedWinners(), count);
         assertTrue(escrow.finalized());
         assertEq(token.balanceOf(winners[0]), 1 ether);

--- a/test/foundry/ContestFactory.t.sol
+++ b/test/foundry/ContestFactory.t.sol
@@ -8,6 +8,7 @@ import {PrizeInfo, PrizeType} from "contracts/modules/contests/shared/PrizeInfo.
 import {MockRegistry} from "contracts/mocks/MockRegistry.sol";
 import {MockFeeManager} from "contracts/mocks/MockFeeManager.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 import {InvalidPrizeData, NotGovernor} from "contracts/errors/Errors.sol";
 import {CoreDefs} from "contracts/interfaces/CoreDefs.sol";
@@ -33,8 +34,10 @@ contract ContestFactoryTest is Test {
         token = new TestToken("T", "T");
         registry = new MockRegistry();
         fee = new MockFeeManager();
-        acc = new AccessControlCenter();
-        acc.initialize(address(this));
+        AccessControlCenter accImpl = new AccessControlCenter();
+        bytes memory accData = abi.encodeCall(AccessControlCenter.initialize, address(this));
+        ERC1967Proxy accProxy = new ERC1967Proxy(address(accImpl), accData);
+        acc = AccessControlCenter(address(accProxy));
         acc.grantRole(acc.GOVERNOR_ROLE(), address(this));
         registry.setCoreService(keccak256("AccessControlCenter"), address(acc));
         validator = new DummyValidator();

--- a/test/foundry/ContestValidator.t.sol
+++ b/test/foundry/ContestValidator.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ContestValidator} from "contracts/modules/contests/ContestValidator.sol";
 import {MockValidator} from "contracts/mocks/MockValidator.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
@@ -18,8 +19,10 @@ contract ContestValidatorTest is Test {
     address internal other = address(0xBEEF);
 
     function setUp() public {
-        acc = new AccessControlCenter();
-        acc.initialize(governor);
+        AccessControlCenter accImpl = new AccessControlCenter();
+        bytes memory accData = abi.encodeCall(AccessControlCenter.initialize, governor);
+        ERC1967Proxy accProxy = new ERC1967Proxy(address(accImpl), accData);
+        acc = AccessControlCenter(address(accProxy));
         acc.grantRole(acc.GOVERNOR_ROLE(), governor);
         mval = new MockValidator();
         val = new ContestValidator(address(acc), address(mval));

--- a/test/foundry/CoreFeeManager.t.sol
+++ b/test/foundry/CoreFeeManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import {CoreFeeManager} from "contracts/core/CoreFeeManager.sol";
 import {AccessControlCenter} from "contracts/core/AccessControlCenter.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {NotFeatureOwner} from "contracts/errors/Errors.sol";
 import {TestToken} from "contracts/mocks/TestToken.sol";
 
@@ -15,11 +16,16 @@ contract CoreFeeManagerTest is Test {
     address internal payer = address(0xBEEF);
 
     function setUp() public {
-        acc = new AccessControlCenter();
-        acc.initialize(address(this));
+        AccessControlCenter accImpl = new AccessControlCenter();
+        bytes memory accData = abi.encodeCall(AccessControlCenter.initialize, address(this));
+        ERC1967Proxy accProxy = new ERC1967Proxy(address(accImpl), accData);
+        acc = AccessControlCenter(address(accProxy));
         acc.grantRole(acc.FEATURE_OWNER_ROLE(), address(this));
-        fee = new CoreFeeManager();
-        fee.initialize(address(acc));
+        acc.grantRole(acc.FEATURE_OWNER_ROLE(), payer);
+        CoreFeeManager feeImpl = new CoreFeeManager();
+        bytes memory feeData = abi.encodeCall(CoreFeeManager.initialize, address(acc));
+        ERC1967Proxy feeProxy = new ERC1967Proxy(address(feeImpl), feeData);
+        fee = CoreFeeManager(address(feeProxy));
         t1 = new TestToken("T1", "T1");
         t2 = new TestToken("T2", "T2");
         t1.transfer(payer, 100 ether);
@@ -31,6 +37,7 @@ contract CoreFeeManagerTest is Test {
         fee.setFixedFee(bytes32("M1"), address(t1), 1 ether);
         vm.prank(payer);
         t1.approve(address(fee), 100 ether);
+        vm.prank(payer);
         uint256 f = fee.collect(bytes32("M1"), address(t1), 20 ether);
         assertEq(f, 2 ether); // 1 ether fixed + 5% of 20 = 2
         assertEq(t1.balanceOf(address(fee)), 2 ether);

--- a/test/foundry/CoreFeeManager.t.sol
+++ b/test/foundry/CoreFeeManager.t.sol
@@ -31,7 +31,7 @@ contract CoreFeeManagerTest is Test {
         fee.setFixedFee(bytes32("M1"), address(t1), 1 ether);
         vm.prank(payer);
         t1.approve(address(fee), 100 ether);
-        uint256 f = fee.collect(bytes32("M1"), address(t1), payer, 20 ether);
+        uint256 f = fee.collect(bytes32("M1"), address(t1), 20 ether);
         assertEq(f, 2 ether); // 1 ether fixed + 5% of 20 = 2
         assertEq(t1.balanceOf(address(fee)), 2 ether);
     }

--- a/test/hardhat/contestEscrow.test.ts
+++ b/test/hardhat/contestEscrow.test.ts
@@ -29,7 +29,7 @@ describe("ContestEscrow", function () {
   });
 
   it("finalize distributes prizes", async () => {
-    await escrow.connect(creator).finalize([w1.address, w2.address], 0, 0);
+    await escrow.connect(creator).finalize([w1.address, w2.address], 0);
     expect(await token.balanceOf(w1.address)).to.equal(ethers.parseEther("100"));
     expect(await token.balanceOf(w2.address)).to.equal(ethers.parseEther("50"));
     expect(await escrow.finalized()).to.equal(true);
@@ -37,7 +37,7 @@ describe("ContestEscrow", function () {
 
   it("reverts with wrong winners count", async () => {
     await expect(
-      escrow.connect(creator).finalize([w1.address], 0, 0)
+      escrow.connect(creator).finalize([w1.address], 0)
     ).to.be.revertedWithCustomError(escrow, "WrongWinnersCount");
   });
 


### PR DESCRIPTION
## Summary
- disable initialization on UUPS upgradeables
- remove unused contest winner commitment logic
- update fee manager to pull tokens from msg.sender
- update scripts and tests for new APIs
- use Address.sendValue for gas refunds

## Testing
- `npx hardhat compile` *(fails: Need to install hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68630105d0c883238275b0d93d4e3476