### PR TITLE
Fix demo deployment with proxy contracts

### DIFF
--- a/contracts/lib/Proxy.sol
+++ b/contracts/lib/Proxy.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// Wrapper contract to ensure Hardhat compiles ERC1967Proxy
+contract ImportedERC1967Proxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data)
+        ERC1967Proxy(logic, data)
+    {}
+}

--- a/scripts/demo/utils/marketplace.ts
+++ b/scripts/demo/utils/marketplace.ts
@@ -18,13 +18,16 @@ async function setupMarketplaceRoles(registry: Contract, addr: string) {
     const relayerRole = await acl.RELAYER_ROLE();
 
     if (!(await acl.hasRole(moduleRole, addr))) {
-        await acl.grantRole(moduleRole, addr);
+        const tx = await acl.grantRole(moduleRole, addr);
+        await tx.wait();
     }
     if (!(await acl.hasRole(featureOwnerRole, addr))) {
-        await acl.grantRole(featureOwnerRole, addr);
+        const tx = await acl.grantRole(featureOwnerRole, addr);
+        await tx.wait();
     }
     if (!(await acl.hasRole(relayerRole, addr))) {
-        await acl.grantRole(relayerRole, addr);
+        const tx = await acl.grantRole(relayerRole, addr);
+        await tx.wait();
     }
 }
 

--- a/scripts/demo/utils/marketplace.ts
+++ b/scripts/demo/utils/marketplace.ts
@@ -7,6 +7,27 @@
 import { ethers } from "hardhat";
 import { Contract } from "ethers";
 
+/** Helper that grants required roles to a marketplace instance */
+async function setupMarketplaceRoles(registry: Contract, addr: string) {
+    const aclAddress = await registry.getCoreService(
+        ethers.keccak256(ethers.toUtf8Bytes("AccessControlCenter"))
+    );
+    const acl = await ethers.getContractAt("AccessControlCenter", aclAddress);
+    const moduleRole = await acl.MODULE_ROLE();
+    const featureOwnerRole = await acl.FEATURE_OWNER_ROLE();
+    const relayerRole = await acl.RELAYER_ROLE();
+
+    if (!(await acl.hasRole(moduleRole, addr))) {
+        await acl.grantRole(moduleRole, addr);
+    }
+    if (!(await acl.hasRole(featureOwnerRole, addr))) {
+        await acl.grantRole(featureOwnerRole, addr);
+    }
+    if (!(await acl.hasRole(relayerRole, addr))) {
+        await acl.grantRole(relayerRole, addr);
+    }
+}
+
 /**
  * Создает маркетплейс через фабрику или напрямую (если вызов фабрики завершается ошибкой)
  * @param marketplaceFactory Контракт фабрики маркетплейса
@@ -42,6 +63,7 @@ export async function createMarketplace(
         if (event && event.args) {
             const marketplaceAddress = event.args.marketplace;
             console.log(`Маркетплейс успешно создан через фабрику: ${marketplaceAddress}`);
+            await setupMarketplaceRoles(registry, marketplaceAddress);
             return marketplaceAddress;
         } else {
             throw new Error("Не удалось найти событие MarketplaceCreated в транзакции");
@@ -116,27 +138,7 @@ async function createMarketplaceDirectly(
     await registry.setModuleServiceAlias(instanceId, "PaymentGateway", gatewayAddress);
 
     // Получаем контракт управления доступом
-    const aclAddress = await registry.getCoreService(ethers.keccak256(ethers.toUtf8Bytes("AccessControlCenter")));
-    const acl = await ethers.getContractAt("AccessControlCenter", aclAddress);
-
-    // Выдаем необходимые роли маркетплейсу
-    console.log("Выдаем необходимые роли маркетплейсу...");
-    const moduleRole = await acl.MODULE_ROLE();
-    const featureOwnerRole = await acl.FEATURE_OWNER_ROLE();
-
-    // Проверяем наличие ролей у маркетплейса
-    const hasModuleRole = await acl.hasRole(moduleRole, marketplaceAddress);
-    const hasFeatureOwnerRole = await acl.hasRole(featureOwnerRole, marketplaceAddress);
-
-    if (!hasModuleRole) {
-        await acl.grantRole(moduleRole, marketplaceAddress);
-        console.log(`Роль MODULE_ROLE выдана маркетплейсу`);
-    }
-
-    if (!hasFeatureOwnerRole) {
-        await acl.grantRole(featureOwnerRole, marketplaceAddress);
-        console.log(`Роль FEATURE_OWNER_ROLE выдана маркетплейсу`);
-    }
+    await setupMarketplaceRoles(registry, marketplaceAddress);
 
     console.log(`Маркетплейс успешно создан и настроен!`);
     return marketplaceAddress;


### PR DESCRIPTION
## Summary
- add helper to deploy upgradeable contracts via `ERC1967Proxy`
- deploy core contracts through proxies in demo deployer

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68639054aa0c83238d8d17c1f12e928d