### PR TITLE
Fix subscription demo payment gateway role

### DIFF
--- a/scripts/demo/subscription-demo.ts
+++ b/scripts/demo/subscription-demo.ts
@@ -46,6 +46,11 @@ async function main() {
     const moduleRole = await acl.MODULE_ROLE();
     await acl.grantRole(featureRole, await manager.getAddress());
     await acl.grantRole(moduleRole, await manager.getAddress());
+
+    // Allow the manager to act as a relayer when calling the PaymentGateway
+    const relayerRole = await acl.RELAYER_ROLE();
+    await acl.grantRole(relayerRole, await manager.getAddress());
+
     const autoRole = await acl.AUTOMATION_ROLE();
     await acl.grantRole(autoRole, keeper.address);
   });


### PR DESCRIPTION
## Summary
- allow SubscriptionManager to call PaymentGateway without a user signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863cf8defac8323901c393328041f26