### PR TITLE
Fix slither config to exclude mocks

### DIFF
--- a/.slither.config.json
+++ b/.slither.config.json
@@ -1,5 +1,5 @@
 {
-  "filter_paths": "contracts/(?!mocks).*,node_modules/,lib/",
+  "filter_paths": "contracts/mocks/|node_modules/|lib/",
   "exclude_informational": true,
   "exclude_low": false,
   "exclude_medium": false,


### PR DESCRIPTION
## Summary
- fix regex in `.slither.config.json` to properly exclude mock contracts from analysis

## Testing
- `forge build --build-info --skip */test/foundry/** */script/** --force`
- `./scripts/security/run-slither.sh --critical-only`

------
https://chatgpt.com/codex/tasks/task_e_6863f3269830832382ea40c9af01c57a