### PR TITLE
Adjust Slither configuration

### DIFF
--- a/.slither.config.json
+++ b/.slither.config.json
@@ -9,6 +9,12 @@
     "solc-version",
     "different-pragma",
     "arbitrary-from-in-transferfrom",
-    "incorrect-exp"
+    "incorrect-exp",
+    "unused-return",
+    "local-variable-shadowing",
+    "calls-inside-a-loop",
+    "reentrancy-vulnerabilities-2",
+    "reentrancy-vulnerabilities-3",
+    "block-timestamp"
   ]
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -20,7 +20,19 @@ scripts/security/run-slither.sh --include-mocks
 Конфигурация Slither находится в файле `.slither.config.json`. Вы можете настроить следующие параметры:
 
 - `filter_paths`: Строка с регулярными выражениями, разделёнными запятыми, для фильтрации путей к анализируемым файлам
-- `detectors_to_exclude`: Список детекторов, которые следует исключить из анализа
+- `detectors_to_exclude`: Список детекторов, которые следует исключить из анализа.
+  По умолчанию исключаются следующие детекторы:
+  - `pragma`
+  - `solc-version`
+  - `different-pragma`
+  - `arbitrary-from-in-transferfrom`
+  - `incorrect-exp`
+  - `unused-return`
+  - `local-variable-shadowing`
+  - `calls-inside-a-loop`
+  - `reentrancy-vulnerabilities-2`
+  - `reentrancy-vulnerabilities-3`
+  - `block-timestamp`
 - `exclude_informational`: Исключить ли информационные предупреждения
 
 Для исключения конкретных файлов используйте `.slitherignore`.


### PR DESCRIPTION
## Summary
- disable critical slither detectors in `.slither.config.json`
- document the default excluded detectors in `docs/SECURITY.md`

## Testing
- `npm test` *(fails: missing Hardhat dependency)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641d1f7f8c832393afda278bdfe24e