### PR TITLE
Fix missing enum definitions

### DIFF
--- a/contracts/payments/interfaces/IGateway.sol
+++ b/contracts/payments/interfaces/IGateway.sol
@@ -7,6 +7,11 @@ import './IPaymentComponent.sol';
 /// @notice Универсальный интерфейс платежного шлюза для обработки платежей
 /// @dev Объединяет все необходимые методы для платежных шлюзов
 interface IGateway is IPaymentComponent {
+    /// @notice Результаты обработки платежа
+    enum PaymentResult {
+        FAILED,
+        SUCCESS
+    }
     /// @notice Универсальный метод обработки платежей
     /// @param moduleId Идентификатор модуля
     /// @param token Адрес токена (address(0) для нативной валюты)

--- a/contracts/payments/interfaces/IPaymentProcessor.sol
+++ b/contracts/payments/interfaces/IPaymentProcessor.sol
@@ -7,6 +7,13 @@ import './IPaymentComponent.sol';
 /// @notice Интерфейс для обработчиков платежей
 /// @dev Каждый обработчик в цепочке должен реализовывать этот интерфейс
 interface IPaymentProcessor is IPaymentComponent {
+    /// @notice Возможные результаты обработки процессором
+    enum ProcessResult {
+        FAILED,
+        SUCCESS,
+        SKIPPED,
+        MODIFIED
+    }
     /// @notice Обработать контекст платежа
     /// @param context Контекст платежа
     /// @return result Результат обработки


### PR DESCRIPTION
## Summary
- add `ProcessResult` enum to `IPaymentProcessor`
- add `PaymentResult` enum to `IGateway`

## Testing
- `npm run compile` *(fails: needs packages)*

------
https://chatgpt.com/codex/tasks/task_e_6870db9ef8d48323a06ce37b62e4cf17