### PR TITLE
Fix demo script with mock payment gateway

### DIFF
--- a/contracts/mocks/MockPaymentGateway.sol
+++ b/contracts/mocks/MockPaymentGateway.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import '../pay/interfaces/IPaymentGateway.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
+contract MockPaymentGateway is IPaymentGateway {
+    using SafeERC20 for IERC20;
+
+    function processPayment(
+        bytes32,
+        address token,
+        address payer,
+        uint256 amount,
+        bytes calldata
+    ) external payable override returns (uint256 netAmount) {
+        if (token == address(0)) {
+            require(msg.value >= amount, 'insufficient value');
+            payable(msg.sender).transfer(amount);
+        } else {
+            IERC20(token).safeTransferFrom(payer, msg.sender, amount);
+        }
+        return amount;
+    }
+
+    function convertAmount(bytes32, address, address, uint256 amount) external pure override returns (uint256) {
+        return amount;
+    }
+
+    function isPairSupported(bytes32, address, address) external pure override returns (bool) {
+        return true;
+    }
+
+    function getSupportedTokens(bytes32) external pure override returns (address[] memory tokens) {
+        tokens = new address[](0);
+    }
+
+    function getPaymentStatus(bytes32) external pure override returns (uint8) {
+        return 1;
+    }
+}

--- a/scripts/demo/marketplaceDemo.ts
+++ b/scripts/demo/marketplaceDemo.ts
@@ -9,7 +9,7 @@ import {
 
 async function main() {
   const [deployer, seller, buyer, buyer2] = await ethers.getSigners();
-  const marketplace = await getMarketplaceContract();
+  const { marketplace, gateway } = await getMarketplaceContract();
 
   const productId = 1;
   const price = ethers.parseEther("1");
@@ -25,7 +25,7 @@ async function main() {
 
   const sellerBefore = await getBalance(seller.address, nativeToken);
   const buyerBefore = await getBalance(buyer.address, nativeToken);
-  await purchaseListing(marketplace, buyer, listing, signature, nativeToken);
+  await purchaseListing(marketplace, gateway, buyer, listing, signature, nativeToken);
   const sellerAfter = await getBalance(seller.address, nativeToken);
   const buyerAfter = await getBalance(buyer.address, nativeToken);
 
@@ -55,6 +55,7 @@ async function main() {
   const buyer2Before = await getBalance(buyer2.address, await testToken.getAddress());
   await purchaseListing(
     marketplace,
+    gateway,
     buyer2,
     listing2,
     signature2,


### PR DESCRIPTION
## Summary
- add `MockPaymentGateway` for transferring demo funds
- adapt helper and demo script to use the mock gateway

## Testing
- `npx hardhat compile --force`
- `npm test`
- `npx hardhat run scripts/demo/marketplaceDemo.ts --network hardhat`

------
https://chatgpt.com/codex/tasks/task_e_6873d05969bc83238e7a0c5faae61823